### PR TITLE
fix: discovery error handling during reconnect

### DIFF
--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -461,6 +461,7 @@ class DenonDevice:
                         _LOG.info("IP address of '%s' changed: %s", self._name, item["host"])
                         self._receiver._host = item["host"]  # pylint: disable=W0212 # seems to be the only way
                         self.events.emit(Events.IP_ADDRESS_CHANGED, self.id, self._receiver.host)
+                        break
         else:
             await asyncio.sleep(backoff)
 

--- a/intg-denonavr/discover.py
+++ b/intg-denonavr/discover.py
@@ -19,11 +19,16 @@ async def denon_avrs() -> list[dict]:
     """
     _LOG.debug("Starting discovery")
 
-    avrs = await denonavr.async_discover()
-    if not avrs:
-        _LOG.info("No AVRs discovered")
+    # extra safety, if anything goes wrong here the reconnection logic is dead
+    try:
+        avrs = await denonavr.async_discover()
+        if not avrs:
+            _LOG.info("No AVRs discovered")
+            return []
+
+        _LOG.info("Found AVR(s): %s", avrs)
+
+        return avrs
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        _LOG.error("Failed to start discovery: %s", ex)
         return []
-
-    _LOG.info("Found AVR(s): %s", avrs)
-
-    return avrs


### PR DESCRIPTION
If anything goes wrong during SSDP discovery and an exception is raised, the reconnect task would be dead and the integration would no longer connect to a device.