### PR TITLE
Remove reconnect delay after standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Remove reconnect delay after standby. Requires new Remote Two firmware ([unfoldedcircle/feature-and-bug-tracker#320](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/320)).
+
 ---
 
 ## v0.2.3 - 2023-11-18

--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -89,8 +89,6 @@ async def on_r2_exit_standby() -> None:
 
     _R2_IN_STANDBY = False
     _LOG.debug("Exit standby event: connecting device(s)")
-    # delay is only a temporary workaround, until the core verifies first that the network is up with an IP address
-    await asyncio.sleep(2)
 
     for configured in _configured_avrs.values():
         # start background task

--- a/intg-denonavr/receiver.py
+++ b/intg-denonavr/receiver.py
@@ -6,6 +6,7 @@ https://github.com/home-assistant/core/blob/dev/homeassistant/components/denonav
 
 License: Apache 2.0
 """
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Requires new Remote Two firmware 1.7.x.

- Relates to unfoldedcircle/feature-and-bug-tracker#320