### PR TITLE
Answer to connect request when already connected (else report as disconnected)

### DIFF
--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -393,6 +393,7 @@ class DenonDevice:
 
         if self._active:
             _LOG.debug("[%s] Already connected", self.id)
+            self.events.emit(Events.CONNECTED, self.id)
             return
 
         self._connecting = True


### PR DESCRIPTION
When the integration is already connected and the remote sends a connect request, the integration will not respond back and will be reported as disconnected. This modification will always report a connect event.
It should be applied to other integrations also that could have the same issue