### PR TITLE
refactor: create a compatible custom integration installation archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             bash -c \
               "cd /workspace && \
               python -m pip install -r requirements.txt && \
-              pyinstaller --clean --onefile --name intg-denonavr intg-denonavr/driver.py"
+              pyinstaller --clean --onedir --name intg-denonavr intg-denonavr/driver.py"
 
       - name: Add version
         run: |
@@ -63,7 +63,9 @@ jobs:
       - name: Prepare artifacts
         shell: bash
         run: |
-          cp dist/intg-denonavr artifacts/
+          mv dist/intg-denonavr artifacts/
+          mv artifacts/intg-denonavr artifacts/bin
+          mv artifacts/bin/intg-denonavr artifacts/bin/driver
           cp driver.json artifacts/
           echo "ARTIFACT_NAME=uc-intg-${{ env.INTG_NAME }}-${{ env.VERSION }}-aarch64" >> $GITHUB_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Create a one-folder bundle with PyInstaller instead a one-file bundle to save resources.
+- Change archive format to the custom integration installation archive.
+- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.
+
 ---
 
 ## v0.4.1 - 2024-06-19

--- a/README.md
+++ b/README.md
@@ -57,12 +57,18 @@ available [environment variables](https://github.com/unfoldedcircle/integration-
 in the Python integration library to control certain runtime features like listening interface and configuration
 directory.
 
-## Build self-contained binary for Remote Two
+## Build distribution binary
 
-After some tests, turns out python stuff on embedded is a nightmare. So we're better off creating a single binary file
-that has everything in it.
+After some tests, turns out Python stuff on embedded is a nightmare. So we're better off creating a binary distribution
+that has everything in it, including the Python runtime and all required modules and native libraries.
 
-To do that, we need to compile it on the target architecture as `pyinstaller` does not support cross compilation.
+To do that, we use [PyInstaller](https://pyinstaller.org/), but it needs to run on the target architecture as
+`PyInstaller` does not support cross compilation.
+
+The `--onefile` option to create a one-file bundled executable should be avoided:
+- Higher startup cost, since the wrapper binary must first extract the archive.
+- Files are extracted to the /tmp directory on the device, which is an in-memory filesystem.  
+  This will further reduce the available memory for the integration drivers!
 
 ### x86-64 Linux
 
@@ -73,7 +79,7 @@ sudo apt install qemu binfmt-support qemu-user-static
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```
 
-Run pyinstaller:
+Run PyInstaller:
 
 ```shell
 docker run --rm --name builder \
@@ -83,7 +89,7 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onefile --name intg-denonavr intg-denonavr/driver.py"
+      pyinstaller --clean --onedir --name intg-denonavr intg-denonavr/driver.py"
 ```
 
 ### aarch64 Linux / Mac
@@ -97,7 +103,7 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onefile --name intg-denonavr intg-denonavr/driver.py"
+      pyinstaller --clean --onedir --name intg-denonavr intg-denonavr/driver.py"
 ```
 
 ## Versioning

--- a/driver.json
+++ b/driver.json
@@ -1,5 +1,5 @@
 {
-  "driver_id": "uc_denon_driver",
+  "driver_id": "denonavr",
   "version": "0.4.1",
   "min_core_api": "0.20.0",
   "name": {


### PR DESCRIPTION
- Create a one-folder bundle with PyInstaller instead a one-file bundle to save resources.
- Change archive format to the [custom integration installation archive](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-installation.md).
- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.