### PR TITLE
Update to Python 3.11.12 and pyinstaller Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
   INTG_NAME: denonavr
   HASH_FILENAME: uc-intg-denonavr.hash
   # Python version to use in the builder image. See https://hub.docker.com/r/arm64v8/python for possible versions.
-  PYTHON_VER: 3.11.6-0.2.0
+  PYTHON_VER: 3.11.12-0.3.0
   BUILD_CHANGELOG: build-changelog.md
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ _Changes in the next release_
 - Power toggle command ([#59](https://github.com/unfoldedcircle/integration-denonavr/pull/59)).
 
 ### Changed
-- Add support article link and change setup description in first setup flow screen.
+- Add a support article link and change the setup description in the first setup flow screen.
 - Use a nicer FontAwesome icon for the integration (tv-music). 
+- Update the embedded Python runtime to 3.11.12 and upgrade common Python libraries like zeroconf and websockets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ docker run --rm --name builder \
     --platform=aarch64 \
     --user=$(id -u):$(id -g) \
     -v "$PWD":/workspace \
-    docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
+    docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
       pyinstaller --clean --onedir --name intg-denonavr intg-denonavr/driver.py"
@@ -256,7 +256,7 @@ On an aarch64 host platform, the build image can be run directly (and much faste
 docker run --rm --name builder \
     --user=$(id -u):$(id -g) \
     -v "$PWD":/workspace \
-    docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
+    docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
       pyinstaller --clean --onedir --name intg-denonavr intg-denonavr/driver.py"


### PR DESCRIPTION
The new r2-pyinstaller 3.11.12-0.3.0 image comes with an updated Python runtime and more importantly, with up-to-date Python libraries like zeroconf and websockets.