### PR TITLE
Additional commands and bug fixes from denonavr dependency + remove hybrid connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,115 +65,257 @@ Supported media player commands:
 
 Additional commands are exposed as "simple commands" that can be used in macros and activities. Many of these commands
 are only supported by specific receiver models. Please check your manual what commands your receiver supports.
+Note that the toggle commands only are available when using Telnet.
 
-| Simple Command              | Denon Command     |
-|-----------------------------|-------------------|
-| OUTPUT_1                    | VSMONI1           |
-| OUTPUT_2                    | VSMONI2           |
-| OUTPUT_AUTO                 | VSMONIAUTO        |
-| DIMMER_TOGGLE               | DIM SEL           |
-| DIMMER_BRIGHT               | DIM BRI           |
-| DIMMER_DIM                  | DIM DIM           |
-| DIMMER_DARK                 | DIM DAR           |
-| DIMMER_OFF                  | DIM OFF           |
-| TRIGGER1_ON                 | TR1 ON            |
-| TRIGGER1_OFF                | TR1 OFF           |
-| TRIGGER2_ON                 | TR2 ON            |
-| TRIGGER2_OFF                | TR2 OFF           |
-| FRONT_LEFT_UP               | CVFL UP           |
-| FRONT_LEFT_DOWN             | CVFL DOWN         |
-| FRONT_RIGHT_UP              | CVFR UP           |
-| FRONT_RIGHT_DOWN            | CVFR DOWN         |
-| CENTER_UP                   | CVC UP            |
-| CENTER_DOWN                 | CVC DOWN          |
-| SUB1_UP                     | CVSW UP           |
-| SUB1_DOWN                   | CVSW DOWN         |
-| SUB2_UP                     | CVSW2 UP          |
-| SUB2_DOWN                   | CVSW2 DOWN        |
-| SUB3_UP                     | CVSW3 UP          |
-| SUB3_DOWN                   | CVSW3 DOWN        |
-| SUB4_UP                     | CVSW4 UP          |
-| SUB4_DOWN                   | CVSW4 DOWN        |
-| SURROUND_LEFT_UP            | CVSL UP           |
-| SURROUND_LEFT_DOWN          | CVSL DOWN         |
-| SURROUND_RIGHT_UP           | CVSR UP           |
-| SURROUND_RIGHT_DOWN         | CVSR DOWN         |
-| SURROUND_BACK_LEFT_UP       | CVSBL UP          |
-| SURROUND_BACK_LEFT_DOWN     | CVSBL DOWN        |
-| SURROUND_BACK_RIGHT_UP      | CVSBR UP          |
-| SURROUND_BACK_RIGHT_DOWN    | CVSBR DOWN        |
-| FRONT_HEIGHT_LEFT_UP        | CVFHL UP          |
-| FRONT_HEIGHT_LEFT_DOWN      | CVFHL DOWN        |
-| FRONT_HEIGHT_RIGHT_UP       | CVFHR UP          |
-| FRONT_HEIGHT_RIGHT_DOWN     | CVFHR DOWN        |
-| FRONT_WIDE_LEFT_UP          | CVFWL UP          |
-| FRONT_WIDE_LEFT_DOWN        | CVFWL DOWN        |
-| FRONT_WIDE_RIGHT_UP         | CVFWR UP          |
-| FRONT_WIDE_RIGHT_DOWN       | CVFWR DOWN        |
-| TOP_FRONT_LEFT_UP           | CVTFL UP          |
-| TOP_FRONT_LEFT_DOWN         | CVTFL DOWN        |
-| TOP_FRONT_RIGHT_UP          | CVTFR UP          |
-| TOP_FRONT_RIGHT_DOWN        | CVTFR DOWN        |
-| TOP_MIDDLE_LEFT_UP          | CVTML UP          |
-| TOP_MIDDLE_LEFT_DOWN        | CVTML DOWN        |
-| TOP_MIDDLE_RIGHT_UP         | CVTMR UP          |
-| TOP_MIDDLE_RIGHT_DOWN       | CVTMR DOWN        |
-| TOP_REAR_LEFT_UP            | CVTRL UP          |
-| TOP_REAR_LEFT_DOWN          | CVTRL DOWN        |
-| TOP_REAR_RIGHT_UP           | CVTRR UP          |
-| TOP_REAR_RIGHT_DOWN         | CVTRR DOWN        |
-| REAR_HEIGHT_LEFT_UP         | CVRHL UP          |
-| REAR_HEIGHT_LEFT_DOWN       | CVRHL DOWN        |
-| REAR_HEIGHT_RIGHT_UP        | CVRHR UP          |
-| REAR_HEIGHT_RIGHT_DOWN      | CVRHR DOWN        |
-| FRONT_DOLBY_LEFT_UP         | CVFDL UP          |
-| FRONT_DOLBY_LEFT_DOWN       | CVFDL DOWN        |
-| FRONT_DOLBY_RIGHT_UP        | CVFDR UP          |
-| FRONT_DOLBY_RIGHT_DOWN      | CVFDR DOWN        |
-| SURROUND_DOLBY_LEFT_UP      | CVSDL UP          |
-| SURROUND_DOLBY_LEFT_DOWN    | CVSDL DOWN        |
-| SURROUND_DOLBY_RIGHT_UP     | CVSDR UP          |
-| SURROUND_DOLBY_RIGHT_DOWN   | CVSDR DOWN        |
-| BACK_DOLBY_LEFT_UP          | CVBDL UP          |
-| BACK_DOLBY_LEFT_DOWN        | CVBDL DOWN        |
-| BACK_DOLBY_RIGHT_UP         | CVBDR UP          |
-| BACK_DOLBY_RIGHT_DOWN       | CVBDR DOWN        |
-| SURROUND_HEIGHT_LEFT_UP     | CVSHL UP          |
-| SURROUND_HEIGHT_LEFT_DOWN   | CVSHL DOWN        |
-| SURROUND_HEIGHT_RIGHT_UP    | CVSHR UP          |
-| SURROUND_HEIGHT_RIGHT_DOWN  | CVSHR DOWN        |
-| TOP_SURROUND_UP             | CVTS UP           |
-| TOP_SURROUND_DOWN           | CVTS DOWN         |
-| CENTER_HEIGHT_UP            | CVCH UP           |
-| CENTER_HEIGHT_DOWN          | CVCH DOWN         |
-| DELAY_UP                    | PSDELAY UP        |
-| DELAY_DOWN                  | PSDELAY DOWN      |
-| SURROUND_MODE_AUTO          | MSAUTO            |
-| SURROUND_MODE_DIRECT        | MSDIRECT          |
-| SURROUND_MODE_PURE_DIRECT   | MSPURE DIRECT     |
-| SURROUND_MODE_DOLBY_DIGITAL | MSDOLBY DIGITAL   |
-| SURROUND_MODE_DTS_SURROUND  | MSDTS SURROUND    |
-| SURROUND_MODE_AURO3D        | MSAURO3D          |
-| SURROUND_MODE_AURO2DSURR    | MSAURO2DSURR      |
-| SURROUND_MODE_MCH_STEREO    | MSMCH STEREO      |
-| SURROUND_MODE_NEXT          | MSLEFT            |
-| SURROUND_MODE_PREVIOUS      | MSRIGHT           |
-| MULTIEQ_REFERENCE           | PSMULTEQ:AUDYSSEY |
-| MULTIEQ_BYPASS_LR           | MULTEQ:BYP.LR     |
-| MULTIEQ_FLAT                | PSMULTEQ:FLAT     |
-| MULTIEQ_OFF                 | PSMULTEQ:OFF      |
-| DYNAMIC_EQ_ON               | PSDYNEQ ON        |
-| DYNAMIC_EQ_OFF              | PSDYNEQ OFF       |
-| AUDYSSEY_LFC                | PSLFC ON          |
-| AUDYSSEY_LFC_OFF            | PSLFC OFF         |
-| DIRAC_LIVE_FILTER_SLOT1     | PSDIRAC 1         |
-| DIRAC_LIVE_FILTER_SLOT2     | PSDIRAC 2         |
-| DIRAC_LIVE_FILTER_SLOT3     | PSDIRAC 3         |
-| DIRAC_LIVE_FILTER_OFF       | PSDIRAC OFF       |
-| ECO_ON                      | ECOON             |
-| ECO_AUTO                    | ECOAUTO           |
-| ECO_OFF                     | ECOOFF            |
-| STATUS                      | RCSHP0230030      |
+| Simple Command                                      | Denon Command         |
+|-----------------------------------------------------|-----------------------|
+| OUTPUT_1                                            | VSMONI1               |
+| OUTPUT_2                                            | VSMONI2               |
+| OUTPUT_AUTO                                         | VSMONIAUTO            |
+| DIMMER_TOGGLE                                       | DIM SEL               |
+| DIMMER_BRIGHT                                       | DIM BRI               |
+| DIMMER_DIM                                          | DIM DIM               |
+| DIMMER_DARK                                         | DIM DAR               |
+| DIMMER_OFF                                          | DIM OFF               |
+| TRIGGER1_ON                                         | TR1 ON                |
+| TRIGGER1_OFF                                        | TR1 OFF               |
+| TRIGGER2_ON                                         | TR2 ON                |
+| TRIGGER2_OFF                                        | TR2 OFF               |
+| TRIGGER3_ON                                         | TR2 ON                |
+| TRIGGER3_OFF                                        | TR2 OFF               |
+| DELAY_UP                                            | PSDELAY UP            |
+| DELAY_DOWN                                          | PSDELAY DOWN          |
+| ECO_AUTO                                            | ECOAUTO               |
+| ECO_ON                                              | ECOON                 |
+| ECO_OFF                                             | ECOOFF                |
+| INFO_MENU                                           | MNINF                 |
+| OPTIONS_MENU                                        | MNOPT                 |
+| CHANNEL_LEVEL_ADJUST_MENU                           | MNCHL                 |
+| AUTO_STANDBY_OFF                                    | STBYOFF               |
+| AUTO_STANDBY_15MIN                                  | STBY15M               |
+| AUTO_STANDBY_30MIN                                  | STBY30M               |
+| AUTO_STANDBY_60MIN                                  | STBY60M               |
+| DELAY_TIME_UP                                       | PSDEL UP              |
+| DELAY_TIME_DOWN                                     | PSDEL DOWN            |
+| HDMI_AUDIO_DECODE_AMP                               | VSAUDIO AMP           |
+| HDMI_AUDIO_DECODE_TV                                | VSAUDIO TV            |
+| VIDEO_PROCESSING_MODE_AUTO                          | VSVPMAUTO             |
+| VIDEO_PROCESSING_MODE_GAME                          | VSVPMGAME             |
+| VIDEO_PROCESSING_MODE_MOVIE                         | VSVPMOVI              |
+| VIDEO_PROCESSING_MODE_BYPASS                        | VSVPMBYP              |
+| NETWORK_RESTART                                     | NSRBT                 |
+| SPEAKER_PRESET_1                                    | SPPR 1                |
+| SPEAKER_PRESET_2                                    | SPPR 2                |
+| SPEAKER_PRESET_TOGGLE                               | SPPR 1/2              |
+| BT_TRANSMITTER_ON                                   | BTTX ON               |
+| BT_TRANSMITTER_OFF                                  | BTTX OFF              |
+| BT_TRANSMITTER_TOGGLE                               | BTTX ON/OFF           |
+| BT_OUTPUT_MODE_BT_SPEAKER                           | BTTX SP               |
+| BT_OUTPUT_MODE_BT_ONLY                              | BTTX BT               |
+| BT_OUTPUT_MODE_TOGGLE                               | BTTX SP/BT            |
+| AUDIO_RESTORER_OFF                                  | PSRSTR OFF            |
+| AUDIO_RESTORER_LOW                                  | PSRSTR LOW            |
+| AUDIO_RESTORER_MEDIUM                               | PSRSTR MED            |
+| AUDIO_RESTORER_HIGH                                 | PSRSTR HI             |
+| REMOTE_CONTROL_LOCK_ON                              | SYREMOTE LOCK ON      |
+| REMOTE_CONTROL_LOCK_OFF                             | SYREMOTE LOCK OFF     |
+| PANEL_LOCK_PANEL                                    | SYPANEL LOCK ON       |
+| PANEL_LOCK_PANEL_VOLUME                             | SYPANEL+V LOCK ON     |
+| PANEL_LOCK_OFF                                      | SYPANEL LOCK OFF      |
+| GRAPHIC_EQ_ON                                       | PSGEQ ON              |
+| GRAPHIC_EQ_OFF                                      | PSGEQ OFF             |
+| GRAPHIC_EQ_TOGGLE                                   | PSGEQ ON/OFF          |
+| HEADPHONE_EQ_ON                                     | PSHEQ ON              |
+| HEADPHONE_EQ_OFF                                    | PSHEQ OFF             |
+| HEADPHONE_EQ_TOGGLE                                 | PSHEQ ON/OFF          |
+| STATUS                                              | RCSHP0230030          |
+| FRONT_LEFT_UP                                       | CVFL UP               |
+| FRONT_LEFT_DOWN                                     | CVFL DOWN             |
+| FRONT_RIGHT_UP                                      | CVFR UP               |
+| FRONT_RIGHT_DOWN                                    | CVFR DOWN             |
+| CENTER_UP                                           | CVC UP                |
+| CENTER_DOWN                                         | CVC DOWN              |
+| SUB1_UP                                             | CVSW UP               |
+| SUB1_DOWN                                           | CVSW DOWN             |
+| SUB2_UP                                             | CVSW2 UP              |
+| SUB2_DOWN                                           | CVSW2 DOWN            |
+| SUB3_UP                                             | CVSW3 UP              |
+| SUB3_DOWN                                           | CVSW3 DOWN            |
+| SUB4_UP                                             | CVSW4 UP              |
+| SUB4_DOWN                                           | CVSW4 DOWN            |
+| SURROUND_LEFT_UP                                    | CVSL UP               |
+| SURROUND_LEFT_DOWN                                  | CVSL DOWN             |
+| SURROUND_RIGHT_UP                                   | CVSR UP               |
+| SURROUND_RIGHT_DOWN                                 | CVSR DOWN             |
+| SURROUND_BACK_LEFT_UP                               | CVSBL UP              |
+| SURROUND_BACK_LEFT_DOWN                             | CVSBL DOWN            |
+| SURROUND_BACK_RIGHT_UP                              | CVSBR UP              |
+| SURROUND_BACK_RIGHT_DOWN                            | CVSBR DOWN            |
+| FRONT_HEIGHT_LEFT_UP                                | CVFHL UP              |
+| FRONT_HEIGHT_LEFT_DOWN                              | CVFHL DOWN            |
+| FRONT_HEIGHT_RIGHT_UP                               | CVFHR UP              |
+| FRONT_HEIGHT_RIGHT_DOWN                             | CVFHR DOWN            |
+| FRONT_WIDE_LEFT_UP                                  | CVFWL UP              |
+| FRONT_WIDE_LEFT_DOWN                                | CVFWL DOWN            |
+| FRONT_WIDE_RIGHT_UP                                 | CVFWR UP              |
+| FRONT_WIDE_RIGHT_DOWN                               | CVFWR DOWN            |
+| TOP_FRONT_LEFT_UP                                   | CVTFL UP              |
+| TOP_FRONT_LEFT_DOWN                                 | CVTFL DOWN            |
+| TOP_FRONT_RIGHT_UP                                  | CVTFR UP              |
+| TOP_FRONT_RIGHT_DOWN                                | CVTFR DOWN            |
+| TOP_MIDDLE_LEFT_UP                                  | CVTML UP              |
+| TOP_MIDDLE_LEFT_DOWN                                | CVTML DOWN            |
+| TOP_MIDDLE_RIGHT_UP                                 | CVTMR UP              |
+| TOP_MIDDLE_RIGHT_DOWN                               | CVTMR DOWN            |
+| TOP_REAR_LEFT_UP                                    | CVTRL UP              |
+| TOP_REAR_LEFT_DOWN                                  | CVTRL DOWN            |
+| TOP_REAR_RIGHT_UP                                   | CVTRR UP              |
+| TOP_REAR_RIGHT_DOWN                                 | CVTRR DOWN            |
+| REAR_HEIGHT_LEFT_UP                                 | CVRHL UP              |
+| REAR_HEIGHT_LEFT_DOWN                               | CVRHL DOWN            |
+| REAR_HEIGHT_RIGHT_UP                                | CVRHR UP              |
+| REAR_HEIGHT_RIGHT_DOWN                              | CVRHR DOWN            |
+| FRONT_DOLBY_LEFT_UP                                 | CVFDL UP              |
+| FRONT_DOLBY_LEFT_DOWN                               | CVFDL DOWN            |
+| FRONT_DOLBY_RIGHT_UP                                | CVFDR UP              |
+| FRONT_DOLBY_RIGHT_DOWN                              | CVFDR DOWN            |
+| SURROUND_DOLBY_LEFT_UP                              | CVSDL UP              |
+| SURROUND_DOLBY_LEFT_DOWN                            | CVSDL DOWN            |
+| SURROUND_DOLBY_RIGHT_UP                             | CVSDR UP              |
+| SURROUND_DOLBY_RIGHT_DOWN                           | CVSDR DOWN            |
+| BACK_DOLBY_LEFT_UP                                  | CVBDL UP              |
+| BACK_DOLBY_LEFT_DOWN                                | CVBDL DOWN            |
+| BACK_DOLBY_RIGHT_UP                                 | CVBDR UP              |
+| BACK_DOLBY_RIGHT_DOWN                               | CVBDR DOWN            |
+| SURROUND_HEIGHT_LEFT_UP                             | CVSHL UP              |
+| SURROUND_HEIGHT_LEFT_DOWN                           | CVSHL DOWN            |
+| SURROUND_HEIGHT_RIGHT_UP                            | CVSHR UP              |
+| SURROUND_HEIGHT_RIGHT_DOWN                          | CVSHR DOWN            |
+| TOP_SURROUND_UP                                     | CVTS UP               |
+| TOP_SURROUND_DOWN                                   | CVTS DOWN             |
+| CENTER_HEIGHT_UP                                    | CVCH UP               |
+| CENTER_HEIGHT_DOWN                                  | CVCH DOWN             |
+| CHANNEL_VOLUMES_RESET                               | CVZRL                 |
+| SUBWOOFER_ON                                        | PSSWR ON              |
+| SUBWOOFER_OFF                                       | PSSWR OFF             |
+| SUBWOOFER_TOGGLE                                    | PSSWR ON/OFF          |
+| SUBWOOFER1_LEVEL_UP                                 | PSSWL UP              |
+| SUBWOOFER1_LEVEL_DOWN                               | PSSWL DOWN            |
+| SUBWOOFER2_LEVEL_UP                                 | PSSWL2 UP             |
+| SUBWOOFER2_LEVEL_DOWN                               | PSSWL2 DOWN           |
+| SUBWOOFER3_LEVEL_UP                                 | PSSWL3 UP             |
+| SUBWOOFER3_LEVEL_DOWN                               | PSSWL3 DOWN           |
+| SUBWOOFER4_LEVEL_UP                                 | PSSWL4 UP             |
+| SUBWOOFER4_LEVEL_DOWN                               | PSSWL4 DOWN           |
+| LFE_UP                                              | PSLFE UP              |
+| LFE_DOWN                                            | PSLFE DOWN            |
+| BASS_SYNC_UP                                        | PSBSC UP              |
+| BASS_SYNC_DOWN                                      | PSBSC DOWN            |
+| SURROUND_MODE_AUTO                                  | MSAUTO                |
+| SURROUND_MODE_DIRECT                                | MSDIRECT              |
+| SURROUND_MODE_PURE_DIRECT                           | MSPURE DIRECT         |
+| SURROUND_MODE_DOLBY_DIGITAL                         | MSDOLBY DIGITAL       |
+| SURROUND_MODE_DTS_SURROUND                          | MSDTS SURROUND        |
+| SURROUND_MODE_AURO3D                                | MSAURO3D              |
+| SURROUND_MODE_AURO2DSURR                            | MSAURO2DSURR          |
+| SURROUND_MODE_MCH_STEREO                            | MSMCH STEREO          |
+| SURROUND_MODE_NEXT                                  | MSRIGHT               |
+| SURROUND_MODE_PREVIOUS                              | MSLEFT                |
+| SOUND_MODE_NEURAL_X_ON                              | PSNEURAL ON           |
+| SOUND_MODE_NEURAL_X_OFF                             | PSNEURAL OFF          |
+| SOUND_MODE_NEURAL_X_TOGGLE                          | PSNEURAL ON/OFF       |
+| SOUND_MODE_IMAX_AUTO                                | PSIMAX AUTO           |
+| SOUND_MODE_IMAX_OFF                                 | PSIMAX OFF            |
+| SOUND_MODE_IMAX_TOGGLE                              | PSIMAX AUTO/OFF       |
+| IMAX_AUDIO_SETTINGS_AUTO                            | PSIMAXAUD AUTO        |
+| IMAX_AUDIO_SETTINGS_MANUAL                          | PSIMAXAUD MANUAL      |
+| IMAX_AUDIO_SETTINGS_TOGGLE                          | PSIMAXAUD AUTO/MANUAL |
+| IMAX_HPF_40HZ                                       | PSIMAXHPF 40          |
+| IMAX_HPF_60HZ                                       | PSIMAXHPF 60          |
+| IMAX_HPF_80HZ                                       | PSIMAXHPF 80          |
+| IMAX_HPF_90HZ                                       | PSIMAXHPF 90          |
+| IMAX_HPF_100HZ                                      | PSIMAXHPF 100         |
+| IMAX_HPF_110HZ                                      | PSIMAXHPF 110         |
+| IMAX_HPF_120HZ                                      | PSIMAXHPF 120         |
+| IMAX_HPF_150HZ                                      | PSIMAXHPF 150         |
+| IMAX_HPF_180HZ                                      | PSIMAXHPF 180         |
+| IMAX_HPF_200HZ                                      | PSIMAXHPF 200         |
+| IMAX_HPF_250HZ                                      | PSIMAXHPF 250         |
+| IMAX_LPF_80HZ                                       | PSIMAXLPF 80          |
+| IMAX_LPF_90HZ                                       | PSIMAXLPF 90          |
+| IMAX_LPF_100HZ                                      | PSIMAXLPF 100         |
+| IMAX_LPF_110HZ                                      | PSIMAXLPF 110         |
+| IMAX_LPF_120HZ                                      | PSIMAXLPF 120         |
+| IMAX_LPF_150HZ                                      | PSIMAXLPF 150         |
+| IMAX_LPF_180HZ                                      | PSIMAXLPF 180         |
+| IMAX_LPF_200HZ                                      | PSIMAXLPF 200         |
+| IMAX_LPF_250HZ                                      | PSIMAXLPF 250         |
+| IMAX_SUBWOOFER_ON                                   | PSIMAXSWM ON          |
+| IMAX_SUBWOOFER_OFF                                  | PSIMAXSWM OFF         |
+| IMAX_SUBWOOFER_OUTPUT_LFE_MAIN                      | PSIMAXSWO L+M         |
+| IMAX_SUBWOOFER_OUTPUT_LFE                           | PSIMAXSWO LFE         |
+| CINEMA_EQ_ON                                        | PSCINEMA EQ.ON        |
+| CINEMA_EQ_OFF                                       | PSCINEMA EQ.OFF       |
+| CINEMA_EQ_TOGGLE                                    | PSCINEMA EQ.ON/OFF    |
+| CENTER_SPREAD_ON                                    | PSCES ON              |
+| CENTER_SPREAD_OFF                                   | PSCES OFF             |
+| CENTER_SPREAD_TOGGLE                                | PSCES ON/OFF          |
+| LOUDNESS_MANAGEMENT_ON                              | PSLOM ON              |
+| LOUDNESS_MANAGEMENT_OFF                             | PSLOM OFF             |
+| LOUDNESS_MANAGEMENT_TOGGLE                          | PSLOM ON/OFF          |
+| DIALOG_ENHANCER_OFF                                 | PSDEH OFF             |
+| DIALOG_ENHANCER_LOW                                 | PSDEH LOW             |
+| DIALOG_ENHANCER_MEDIUM                              | PSDEH MED             |
+| DIALOG_ENHANCER_HIGH                                | PSDEH HIGH            |
+| AUROMATIC_3D_PRESET_SMALL                           | PSAUROPR SMA          |
+| AUROMATIC_3D_PRESET_MEDIUM                          | PSAUROPR MED          |
+| AUROMATIC_3D_PRESET_LARGE                           | PSAUROPR LAR          |
+| AUROMATIC_3D_PRESET_SPEECH                          | PSAUROPR SPE          |
+| AUROMATIC_3D_PRESET_MOVIE                           | PSAUROPR MOV          |
+| AUROMATIC_3D_STRENGTH_UP                            | PSAUROST UP           |
+| AUROMATIC_3D_STRENGTH_DOWN                          | PSAUROST DOWN         |
+| AURO_3D_MODE_DIRECT                                 | PSAUROMODE DRCT       |
+| AURO_3D_MODE_CHANNEL_EXPANSION                      | PSAUROMODE EXP        |
+| DIALOG_CONTROL_UP                                   | PSDIC UP              |
+| DIALOG_CONTROL_DOWN                                 | PSDIC DOWN            |
+| SPEAKER_VIRTUALIZER_ON                              | PSSPV ON              |
+| SPEAKER_VIRTUALIZER_OFF                             | PSSPV OFF             |
+| SPEAKER_VIRTUALIZER_TOGGLE                          | PSSPV ON/OFF          |
+| EFFECT_SPEAKER_SELECTION_FLOOR                      | PSSP:FL               |
+| EFFECT_SPEAKER_SELECTION_FRONT                      | PSSP:FR               |
+| EFFECT_SPEAKER_SELECTION_FRONT_HEIGHT               | PSSP:FH               |
+| EFFECT_SPEAKER_SELECTION_FRONT_WIDE                 | PSSP:FW               |
+| EFFECT_SPEAKER_SELECTION_FRONT_HEIGHT_WIDE          | PSSP:HW               |
+| EFFECT_SPEAKER_SELECTION_HEIGHT_FLOOR               | PSSP:HF               |
+| EFFECT_SPEAKER_SELECTION_SURROUND_BACK              | PSSP:SB               |
+| EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_HEIGHT | PSSP:BH               |
+| EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_WIDE   | PSSP:BW               |
+| DRC_AUTO                                            | PSDRC AUTO            |
+| DRC_LOW                                             | PSDRC LOW             |
+| DRC_MID                                             | PSDRC MID             |
+| DRC_HI                                              | PSDRC HI              |
+| DRC_OFF                                             | PSDRC OFF             |
+| MULTIEQ_REFERENCE                                   | PSMULTEQ:AUDYSSEY     |
+| MULTIEQ_BYPASS_LR                                   | MULTEQ:BYP.LR         |
+| MULTIEQ_FLAT                                        | PSMULTEQ:FLAT         |
+| MULTIEQ_OFF                                         | PSMULTEQ:OFF          |
+| DYNAMIC_EQ_ON                                       | PSDYNEQ ON            |
+| DYNAMIC_EQ_OFF                                      | PSDYNEQ OFF           |
+| DYNAMIC_EQ_TOGGLE                                   | PSDYNEQ OFF           |
+| DYNAMIC_VOLUME_OFF                                  | PSDYNVOL OFF          |
+| AUDYSSEY_LFC                                        | PSLFC ON              |
+| AUDYSSEY_LFC_OFF                                    | PSLFC OFF             |
+| DYNAMIC_VOLUME_LIGHT                                | PSDYNVOL LIT          |
+| DYNAMIC_VOLUME_MEDIUM                               | PSDYNVOL MED          |
+| DYNAMIC_VOLUME_HEAVY                                | PSDYNVOL HEV          |
+| CONTAINMENT_AMOUNT_UP                               | PSCNTAMT UP           |
+| CONTAINMENT_AMOUNT_DOWN                             | PSCNTAMT DOWN         |
+| DIRAC_LIVE_FILTER_SLOT1                             | PSDIRAC 1             |
+| DIRAC_LIVE_FILTER_SLOT2                             | PSDIRAC 2             |
+| DIRAC_LIVE_FILTER_SLOT3                             | PSDIRAC 3             |
+| DIRAC_LIVE_FILTER_OFF                               | PSDIRAC OFF           |
+
+
 
 ## Known supported devices
 

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -33,6 +33,7 @@ from denonavr.exceptions import (
     DenonAvrError,
 )
 from pyee.asyncio import AsyncIOEventEmitter
+from simplecommand import SimpleCommand
 from ucapi.media_player import Attributes as MediaAttr
 
 _LOG = logging.getLogger(__name__)
@@ -212,6 +213,7 @@ class DenonDevice:
             host=device.address, show_all_inputs=device.show_all_inputs, timeout=timeout, add_zones=self._zones
         )
         self._update_audyssey = device.update_audyssey
+        self._simple_command = SimpleCommand(self._receiver, self._send_command_wrapper)
 
         self._active: bool = False
         self._use_telnet = device.use_telnet
@@ -822,6 +824,11 @@ class DenonDevice:
         The command is either sent over telnet, if it is active, or with a http request.
         """
         return await self._send_command(cmd)
+
+    @async_handle_denonlib_errors
+    async def send_simple_command(self, cmd: str) -> ucapi.StatusCodes:
+        """Send a simple command to the AVR."""
+        return await self._simple_command.send_simple_command(cmd)
 
     async def _send_command(self, cmd: str) -> ucapi.StatusCodes:
         """Send a command without error wrapper."""

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -213,7 +213,7 @@ class DenonDevice:
             host=device.address, show_all_inputs=device.show_all_inputs, timeout=timeout, add_zones=self._zones
         )
         self._update_audyssey = device.update_audyssey
-        self._simple_command = SimpleCommand(self._receiver, self._send_command_wrapper)
+        self._simple_command = SimpleCommand(self._receiver, self._send_command)
 
         self._active: bool = False
         self._use_telnet = device.use_telnet

--- a/intg-denonavr/media_player.py
+++ b/intg-denonavr/media_player.py
@@ -10,6 +10,12 @@ from typing import Any
 
 import avr
 from config import AvrDevice, create_entity_id
+from simplecommand import (
+    ALL_COMMANDS,
+    ALL_COMMANDS_DENON,
+    ALL_COMMANDS_TELNET,
+    ALL_COMMANDS_TELNET_DENON,
+)
 from ucapi import EntityTypes, MediaPlayer, StatusCodes
 from ucapi.media_player import (
     Attributes,
@@ -30,120 +36,6 @@ MEDIA_PLAYER_STATE_MAPPING = {
     avr.States.PLAYING: States.PLAYING,
     avr.States.UNAVAILABLE: States.UNAVAILABLE,
     avr.States.UNKNOWN: States.UNKNOWN,
-}
-
-
-SimpleCommandMappings = {
-    "OUTPUT_1": "VSMONI1",
-    "OUTPUT_2": "VSMONI2",
-    "OUTPUT_AUTO": "VSMONIAUTO",
-    "DIMMER_TOGGLE": "DIM SEL",
-    "DIMMER_BRIGHT": "DIM BRI",
-    "DIMMER_DIM": "DIM DIM",
-    "DIMMER_DARK": "DIM DAR",
-    "DIMMER_OFF": "DIM OFF",
-    "TRIGGER1_ON": "TR1 ON",
-    "TRIGGER1_OFF": "TR1 OFF",
-    "TRIGGER2_ON": "TR2 ON",
-    "TRIGGER2_OFF": "TR2 OFF",
-    "FRONT_LEFT_UP": "CVFL UP",
-    "FRONT_LEFT_DOWN": "CVFL DOWN",
-    "FRONT_RIGHT_UP": "CVFR UP",
-    "FRONT_RIGHT_DOWN": "CVFR DOWN",
-    "CENTER_UP": "CVC UP",
-    "CENTER_DOWN": "CVC DOWN",
-    "SUB1_UP": "CVSW UP",
-    "SUB1_DOWN": "CVSW DOWN",
-    "SUB2_UP": "CVSW2 UP",
-    "SUB2_DOWN": "CVSW2 DOWN",
-    "SUB3_UP": "CVSW3 UP",
-    "SUB3_DOWN": "CVSW3 DOWN",
-    "SUB4_UP": "CVSW4 UP",
-    "SUB4_DOWN": "CVSW4 DOWN",
-    "SURROUND_LEFT_UP": "CVSL UP",
-    "SURROUND_LEFT_DOWN": "CVSL DOWN",
-    "SURROUND_RIGHT_UP": "CVSR UP",
-    "SURROUND_RIGHT_DOWN": "CVSR DOWN",
-    "SURROUND_BACK_LEFT_UP": "CVSBL UP",
-    "SURROUND_BACK_LEFT_DOWN": "CVSBL DOWN",
-    "SURROUND_BACK_RIGHT_UP": "CVSBR UP",
-    "SURROUND_BACK_RIGHT_DOWN": "CVSBR DOWN",
-    "FRONT_HEIGHT_LEFT_UP": "CVFHL UP",
-    "FRONT_HEIGHT_LEFT_DOWN": "CVFHL DOWN",
-    "FRONT_HEIGHT_RIGHT_UP": "CVFHR UP",
-    "FRONT_HEIGHT_RIGHT_DOWN": "CVFHR DOWN",
-    "FRONT_WIDE_LEFT_UP": "CVFWL UP",
-    "FRONT_WIDE_LEFT_DOWN": "CVFWL DOWN",
-    "FRONT_WIDE_RIGHT_UP": "CVFWR UP",
-    "FRONT_WIDE_RIGHT_DOWN": "CVFWR DOWN",
-    "TOP_FRONT_LEFT_UP": "CVTFL UP",
-    "TOP_FRONT_LEFT_DOWN": "CVTFL DOWN",
-    "TOP_FRONT_RIGHT_UP": "CVTFR UP",
-    "TOP_FRONT_RIGHT_DOWN": "CVTFR DOWN",
-    "TOP_MIDDLE_LEFT_UP": "CVTML UP",
-    "TOP_MIDDLE_LEFT_DOWN": "CVTML DOWN",
-    "TOP_MIDDLE_RIGHT_UP": "CVTMR UP",
-    "TOP_MIDDLE_RIGHT_DOWN": "CVTMR DOWN",
-    "TOP_REAR_LEFT_UP": "CVTRL UP",
-    "TOP_REAR_LEFT_DOWN": "CVTRL DOWN",
-    "TOP_REAR_RIGHT_UP": "CVTRR UP",
-    "TOP_REAR_RIGHT_DOWN": "CVTRR DOWN",
-    "REAR_HEIGHT_LEFT_UP": "CVRHL UP",
-    "REAR_HEIGHT_LEFT_DOWN": "CVRHL DOWN",
-    "REAR_HEIGHT_RIGHT_UP": "CVRHR UP",
-    "REAR_HEIGHT_RIGHT_DOWN": "CVRHR DOWN",
-    "FRONT_DOLBY_LEFT_UP": "CVFDL UP",
-    "FRONT_DOLBY_LEFT_DOWN": "CVFDL DOWN",
-    "FRONT_DOLBY_RIGHT_UP": "CVFDR UP",
-    "FRONT_DOLBY_RIGHT_DOWN": "CVFDR DOWN",
-    "SURROUND_DOLBY_LEFT_UP": "CVSDL UP",
-    "SURROUND_DOLBY_LEFT_DOWN": "CVSDL DOWN",
-    "SURROUND_DOLBY_RIGHT_UP": "CVSDR UP",
-    "SURROUND_DOLBY_RIGHT_DOWN": "CVSDR DOWN",
-    "BACK_DOLBY_LEFT_UP": "CVBDL UP",
-    "BACK_DOLBY_LEFT_DOWN": "CVBDL DOWN",
-    "BACK_DOLBY_RIGHT_UP": "CVBDR UP",
-    "BACK_DOLBY_RIGHT_DOWN": "CVBDR DOWN",
-    "SURROUND_HEIGHT_LEFT_UP": "CVSHL UP",
-    "SURROUND_HEIGHT_LEFT_DOWN": "CVSHL DOWN",
-    "SURROUND_HEIGHT_RIGHT_UP": "CVSHR UP",
-    "SURROUND_HEIGHT_RIGHT_DOWN": "CVSHR DOWN",
-    "TOP_SURROUND_UP": "CVTS UP",
-    "TOP_SURROUND_DOWN": "CVTS DOWN",
-    "CENTER_HEIGHT_UP": "CVCH UP",
-    "CENTER_HEIGHT_DOWN": "CVCH DOWN",
-    "DELAY_UP": "PSDELAY UP",
-    "DELAY_DOWN": "PSDELAY DOWN",
-    "SURROUND_MODE_AUTO": "MSAUTO",
-    "SURROUND_MODE_DIRECT": "MSDIRECT",
-    "SURROUND_MODE_PURE_DIRECT": "MSPURE DIRECT",
-    "SURROUND_MODE_DOLBY_DIGITAL": "MSDOLBY DIGITAL",
-    "SURROUND_MODE_DTS_SURROUND": "MSDTS SURROUND",
-    "SURROUND_MODE_AURO3D": "MSAURO3D",
-    "SURROUND_MODE_AURO2DSURR": "MSAURO2DSURR",
-    "SURROUND_MODE_MCH_STEREO": "MSMCH STEREO",
-    "SURROUND_MODE_NEXT": "MSLEFT",
-    "SURROUND_MODE_PREVIOUS": "MSRIGHT",
-    "MULTIEQ_REFERENCE": "PSMULTEQ:AUDYSSEY",
-    "MULTIEQ_BYPASS_LR": "MULTEQ:BYP.LR",
-    "MULTIEQ_FLAT": "PSMULTEQ:FLAT",
-    "MULTIEQ_OFF": "PSMULTEQ:OFF",
-    "DYNAMIC_EQ_ON": "PSDYNEQ ON",
-    "DYNAMIC_EQ_OFF": "PSDYNEQ OFF",
-    "AUDYSSEY_LFC": "PSLFC ON",
-    "AUDYSSEY_LFC_OFF": "PSLFC OFF",
-    "DIRAC_LIVE_FILTER_SLOT1": "PSDIRAC 1",
-    "DIRAC_LIVE_FILTER_SLOT2": "PSDIRAC 2",
-    "DIRAC_LIVE_FILTER_SLOT3": "PSDIRAC 3",
-    "DIRAC_LIVE_FILTER_OFF": "PSDIRAC OFF",
-    "ECO_ON": "ECOON",
-    "ECO_AUTO": "ECOAUTO",
-    "ECO_OFF": "ECOOFF",
-}
-
-SimpleCommandMappingsDenon = {
-    **SimpleCommandMappings,
-    "STATUS": "RCSHP0230030",
 }
 
 
@@ -194,9 +86,15 @@ class DenonMediaPlayer(MediaPlayer):
 
         # Denon has additional simple commands
         if "denon" in device.name.lower():
-            self.simple_commands = [*SimpleCommandMappingsDenon]
+            if device.use_telnet:
+                self.simple_commands = [*ALL_COMMANDS_TELNET_DENON]
+            else:
+                self.simple_commands = [*ALL_COMMANDS_DENON]
         else:
-            self.simple_commands = [*SimpleCommandMappings]
+            if device.use_telnet:
+                self.simple_commands = [*ALL_COMMANDS_TELNET]
+            else:
+                self.simple_commands = [*ALL_COMMANDS]
 
         options = {Options.SIMPLE_COMMANDS: self.simple_commands}
 
@@ -269,8 +167,8 @@ class DenonMediaPlayer(MediaPlayer):
             case Commands.INFO:
                 res = await self._receiver.info()
             # Use SimpleCommandMappingsDenon as it covers both the shared and Denon specific commands
-            case cmd if cmd in SimpleCommandMappingsDenon:
-                res = await self._receiver.send_command(SimpleCommandMappingsDenon[cmd])
+            case cmd if cmd in ALL_COMMANDS_TELNET_DENON:
+                res = await self._receiver.send_simple_command(cmd)
             case _:
                 return StatusCodes.NOT_IMPLEMENTED
 

--- a/intg-denonavr/receiver.py
+++ b/intg-denonavr/receiver.py
@@ -28,7 +28,6 @@ class ConnectDenonAVR:
         zone2: bool,
         zone3: bool,
         use_telnet: bool,
-        use_telnet_for_events: bool,
         update_audyssey: bool,
     ) -> None:
         """Initialize the class."""
@@ -37,7 +36,6 @@ class ConnectDenonAVR:
         self._show_all_inputs = show_all_inputs
         self._timeout = timeout
         self._use_telnet = use_telnet
-        self._use_telnet_for_events = use_telnet_for_events
         self._update_audyssey = update_audyssey
 
         self._zones: dict[str, str | None] = {}
@@ -93,7 +91,7 @@ class ConnectDenonAVR:
         )
         await receiver.async_setup()
         # Do an initial update if telnet is used.
-        if self._use_telnet or self._use_telnet_for_events:
+        if self._use_telnet:
             await receiver.async_update()
             if self._update_audyssey:
                 await receiver.async_update_audyssey()

--- a/intg-denonavr/setup_flow.py
+++ b/intg-denonavr/setup_flow.py
@@ -378,7 +378,6 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
             zone2=False,
             zone3=False,
             use_telnet=False,
-            use_telnet_for_events=False,
             update_audyssey=False,
         )
 
@@ -464,7 +463,6 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
     zone3 = msg.input_values.get("zone3") == "true"
     connection_mode = msg.input_values.get("connection_mode")
     use_telnet = connection_mode == "use_telnet"
-    use_telnet_for_events = connection_mode == "use_telnet_for_events"
     volume_step = 0.5
     try:
         volume_step = float(msg.input_values.get("volume_step", 0.5))
@@ -481,7 +479,6 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
         zone2,
         zone3,
         use_telnet=False,  # always False, connection only used to retrieve model information
-        use_telnet_for_events=False,  # always False, connection only used to retrieve model information
         update_audyssey=False,  # always False, connection only used to retrieve model information
     )
 
@@ -508,7 +505,6 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
         receiver.support_sound_mode,
         show_all_inputs,
         use_telnet=use_telnet,
-        use_telnet_for_events=use_telnet_for_events,
         update_audyssey=update_audyssey,
         zone2=zone2,
         zone3=zone3,
@@ -596,14 +592,6 @@ def __connection_mode_cfg(mode: str):
                             "en": "Use Telnet connection",
                             "de": "Telnet-Verbindung verwenden",
                             "fr": "Utilise une connexion Telnet",
-                        },
-                    },
-                    {
-                        "id": "use_telnet_for_events",
-                        "label": {
-                            "en": "Use Telnet connection for events",
-                            "de": "Telnet-Verbindung für Ereignisse verwenden",
-                            "fr": "Utilise une connexion Telnet pour les événements",
                         },
                     },
                     {

--- a/intg-denonavr/simplecommand.py
+++ b/intg-denonavr/simplecommand.py
@@ -1,0 +1,788 @@
+"""
+This module implements the Denon AVR receiver communication of the Remote Two integration driver.
+
+:copyright: (c) 2023 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+from typing import Awaitable, Callable
+
+import denonavr
+import ucapi
+
+CORE_COMMANDS = {
+    "OUTPUT_1",
+    "OUTPUT_2",
+    "OUTPUT_AUTO",
+    "DIMMER_TOGGLE",
+    "DIMMER_BRIGHT",
+    "DIMMER_DIM",
+    "DIMMER_DARK",
+    "DIMMER_OFF",
+    "TRIGGER1_ON",
+    "TRIGGER1_OFF",
+    "TRIGGER2_ON",
+    "TRIGGER2_OFF",
+    "TRIGGER3_ON",
+    "TRIGGER3_OFF",
+    "DELAY_UP",
+    "DELAY_DOWN",
+    "ECO_ON",
+    "ECO_AUTO",
+    "ECO_OFF",
+    "INFO_MENU",
+    "OPTIONS_MENU",
+    "CHANNEL_LEVEL_ADJUST_MENU",
+    "AUTO_STANDBY_OFF",
+    "AUTO_STANDBY_15MIN",
+    "AUTO_STANDBY_30MIN",
+    "AUTO_STANDBY_60MIN",
+    "DELAY_TIME_UP",
+    "DELAY_TIME_DOWN",
+    "HDMI_AUDIO_DECODE_AMP",
+    "HDMI_AUDIO_DECODE_TV",
+    "VIDEO_PROCESSING_MODE_AUTO",
+    "VIDEO_PROCESSING_MODE_GAME",
+    "VIDEO_PROCESSING_MODE_MOVIE",
+    "VIDEO_PROCESSING_MODE_BYPASS",
+    "NETWORK_RESTART",
+    "SPEAKER_PRESET_1",
+    "SPEAKER_PRESET_2",
+    "BT_TRANSMITTER_ON",
+    "BT_TRANSMITTER_OFF",
+    "BT_OUTPUT_MODE_BT_SPEAKER",
+    "BT_OUTPUT_MODE_BT_ONLY",
+    "AUDIO_RESTORER_OFF",
+    "AUDIO_RESTORER_LOW",
+    "AUDIO_RESTORER_MEDIUM",
+    "AUDIO_RESTORER_HIGH",
+    "REMOTE_CONTROL_LOCK_ON",
+    "REMOTE_CONTROL_LOCK_OFF",
+    "PANEL_LOCK_PANEL",
+    "PANEL_LOCK_PANEL_VOLUME",
+    "PANEL_LOCK_OFF",
+    "GRAPHIC_EQ_ON",
+    "GRAPHIC_EQ_OFF",
+    "HEADPHONE_EQ_ON",
+    "HEADPHONE_EQ_OFF",
+}
+
+CORE_COMMANDS_TELNET = {
+    *CORE_COMMANDS,
+    "SPEAKER_PRESET_TOGGLE",
+    "BT_TRANSMITTER_TOGGLE",
+    "BT_OUTPUT_MODE_TOGGLE",
+    "GRAPHIC_EQ_TOGGLE",
+    "HEADPHONE_EQ_TOGGLE",
+}
+
+CORE_COMMANDS_DENON = {
+    *CORE_COMMANDS,
+    "STATUS",
+}
+
+CORE_COMMANDS_DENON_TELNET = {*CORE_COMMANDS_TELNET, "STATUS"}
+
+SOUND_MODE_COMMANDS = {
+    "SURROUND_MODE_AUTO",
+    "SURROUND_MODE_DIRECT",
+    "SURROUND_MODE_PURE_DIRECT",
+    "SURROUND_MODE_DOLBY_DIGITAL",
+    "SURROUND_MODE_DTS_SURROUND",
+    "SURROUND_MODE_AURO3D",
+    "SURROUND_MODE_AURO2DSURR",
+    "SURROUND_MODE_MCH_STEREO",
+    "SURROUND_MODE_NEXT",
+    "SURROUND_MODE_PREVIOUS",
+    "SOUND_MODE_NEURAL_X_ON",
+    "SOUND_MODE_NEURAL_X_OFF",
+    "SOUND_MODE_IMAX_AUTO",
+    "SOUND_MODE_IMAX_OFF",
+    "IMAX_AUDIO_SETTINGS_AUTO",
+    "IMAX_AUDIO_SETTINGS_MANUAL",
+    # IMAX HPF and LPF?
+    "IMAX_SUBWOOFER_ON",
+    "IMAX_SUBWOOFER_OFF",
+    "IMAX_SUBWOOFER_OUTPUT_LFE_MAIN",
+    "IMAX_SUBWOOFER_OUTPUT_LFE",
+    "CINEMA_EQ_ON",
+    "CINEMA_EQ_OFF",
+    "CENTER_SPREAD_ON",
+    "CENTER_SPREAD_OFF",
+    "LOUDNESS_MANAGEMENT_ON",
+    "LOUDNESS_MANAGEMENT_OFF",
+    "DIALOG_ENHANCER_OFF",
+    "DIALOG_ENHANCER_LOW",
+    "DIALOG_ENHANCER_MEDIUM",
+    "DIALOG_ENHANCER_HIGH",
+    "AUROMATIC_3D_PRESET_SMALL",
+    "AUROMATIC_3D_PRESET_MEDIUM",
+    "AUROMATIC_3D_PRESET_LARGE",
+    "AUROMATIC_3D_PRESET_SPEECH",
+    "AUROMATIC_3D_PRESET_MOVIE",
+    "AUROMATIC_3D_STRENGTH_UP",
+    "AUROMATIC_3D_STRENGTH_DOWN",
+    "AURO_3D_MODE_DIRECT",
+    "AURO_3D_MODE_CHANNEL_EXPANSION",
+    "DIALOG_CONTROL_UP",
+    "DIALOG_CONTROL_DOWN",
+    "SPEAKER_VIRTUALIZER_ON",
+    "SPEAKER_VIRTUALIZER_OFF",
+    "EFFECT_SPEAKER_SELECTION_FLOOR",
+    "EFFECT_SPEAKER_SELECTION_HEIGHT_FLOOR",
+    "DRC_AUTO",
+    "DRC_LOW",
+    "DRC_MID",
+    "DRC_HI",
+    "DRC_OFF",
+}
+
+SOUND_MODE_COMMANDS_TELNET = {
+    *SOUND_MODE_COMMANDS,
+    "SOUND_MODE_NEURAL_X_TOGGLE",
+    "SOUND_MODE_IMAX_TOGGLE",
+    "IMAX_AUDIO_SETTINGS_TOGGLE",
+    "CINEMA_EQ_TOGGLE",
+    "CENTER_SPREAD_TOGGLE",
+    "LOUDNESS_MANAGEMENT_TOGGLE",
+    "SPEAKER_VIRTUALIZER_TOGGLE",
+    "EFFECT_SPEAKER_SELECTION_TOGGLE",
+}
+
+AUDYSSEY_COMMANDS = {
+    "MULTIEQ_REFERENCE",
+    "MULTIEQ_BYPASS_LR",
+    "MULTIEQ_FLAT",
+    "MULTIEQ_OFF",
+    "DYNAMIC_EQ_ON",
+    "DYNAMIC_EQ_OFF",
+    "DYNAMIC_EQ_TOGGLE",
+    "AUDYSSEY_LFC",
+    "AUDYSSEY_LFC_OFF",
+    "AUDYSSEY_LFC_TOGGLE",
+    "DYNAMIC_VOLUME_OFF",
+    "DYNAMIC_VOLUME_LIGHT",
+    "DYNAMIC_VOLUME_MEDIUM",
+    "DYNAMIC_VOLUME_HEAVY",
+    "CONTAINMENT_AMOUNT_UP",
+    "CONTAINMENT_AMOUNT_DOWN",
+}
+
+DIRAC_COMMANDS = {
+    "DIRAC_LIVE_FILTER_SLOT1",
+    "DIRAC_LIVE_FILTER_SLOT2",
+    "DIRAC_LIVE_FILTER_SLOT3",
+    "DIRAC_LIVE_FILTER_OFF",
+}
+
+VOLUME_COMMANDS = {
+    "FRONT_LEFT_UP",
+    "FRONT_LEFT_DOWN",
+    "FRONT_RIGHT_UP",
+    "FRONT_RIGHT_DOWN",
+    "CENTER_UP",
+    "CENTER_DOWN",
+    "SUB1_UP",
+    "SUB1_DOWN",
+    "SUB2_UP",
+    "SUB2_DOWN",
+    "SUB3_UP",
+    "SUB3_DOWN",
+    "SUB4_UP",
+    "SUB4_DOWN",
+    "SURROUND_LEFT_UP",
+    "SURROUND_LEFT_DOWN",
+    "SURROUND_RIGHT_UP",
+    "SURROUND_RIGHT_DOWN",
+    "SURROUND_BACK_LEFT_UP",
+    "SURROUND_BACK_LEFT_DOWN",
+    "SURROUND_BACK_RIGHT_UP",
+    "SURROUND_BACK_RIGHT_DOWN",
+    "FRONT_HEIGHT_LEFT_UP",
+    "FRONT_HEIGHT_LEFT_DOWN",
+    "FRONT_HEIGHT_RIGHT_UP",
+    "FRONT_HEIGHT_RIGHT_DOWN",
+    "FRONT_WIDE_LEFT_UP",
+    "FRONT_WIDE_LEFT_DOWN",
+    "FRONT_WIDE_RIGHT_UP",
+    "FRONT_WIDE_RIGHT_DOWN",
+    "TOP_FRONT_LEFT_UP",
+    "TOP_FRONT_LEFT_DOWN",
+    "TOP_FRONT_RIGHT_UP",
+    "TOP_FRONT_RIGHT_DOWN",
+    "TOP_MIDDLE_LEFT_UP",
+    "TOP_MIDDLE_LEFT_DOWN",
+    "TOP_MIDDLE_RIGHT_UP",
+    "TOP_MIDDLE_RIGHT_DOWN",
+    "TOP_REAR_LEFT_UP",
+    "TOP_REAR_LEFT_DOWN",
+    "TOP_REAR_RIGHT_UP",
+    "TOP_REAR_RIGHT_DOWN",
+    "REAR_HEIGHT_LEFT_UP",
+    "REAR_HEIGHT_LEFT_DOWN",
+    "REAR_HEIGHT_RIGHT_UP",
+    "REAR_HEIGHT_RIGHT_DOWN",
+    "FRONT_DOLBY_LEFT_UP",
+    "FRONT_DOLBY_LEFT_DOWN",
+    "FRONT_DOLBY_RIGHT_UP",
+    "FRONT_DOLBY_RIGHT_DOWN",
+    "SURROUND_DOLBY_LEFT_UP",
+    "SURROUND_DOLBY_LEFT_DOWN",
+    "SURROUND_DOLBY_RIGHT_UP",
+    "SURROUND_DOLBY_RIGHT_DOWN",
+    "BACK_DOLBY_LEFT_UP",
+    "BACK_DOLBY_LEFT_DOWN",
+    "BACK_DOLBY_RIGHT_UP",
+    "BACK_DOLBY_RIGHT_DOWN",
+    "SURROUND_HEIGHT_LEFT_UP",
+    "SURROUND_HEIGHT_LEFT_DOWN",
+    "SURROUND_HEIGHT_RIGHT_UP",
+    "SURROUND_HEIGHT_RIGHT_DOWN",
+    "TOP_SURROUND_UP",
+    "TOP_SURROUND_DOWN",
+    "CENTER_HEIGHT_UP",
+    "CENTER_HEIGHT_DOWN",
+    "CHANNEL_VOLUMES_RESET",
+    "SUBWOOFER_ON",
+    "SUBWOOFER_OFF",
+    "SUBWOOFER_LEVE_UP",
+    "SUBWOOFER_LEVEL_DOWN",
+    "SUBWOOFER2_LEVE_UP",
+    "SUBWOOFER2_LEVEL_DOWN",
+    "SUBWOOFER3_LEVE_UP",
+    "SUBWOOFER3_LEVEL_DOWN",
+    "SUBWOOFER4_LEVE_UP",
+    "SUBWOOFER4_LEVEL_DOWN",
+    "LFE_UP",
+    "LFE_DOWN",
+    "BASS_SYNC_UP",
+    "BASS_SYNC_DOWN",
+}
+
+VOLUME_COMMANDS_TELNET = {
+    *VOLUME_COMMANDS,
+    "SUBWOOFER_TOGGLE",
+}
+
+ALL_COMMANDS = {
+    *CORE_COMMANDS,
+    *SOUND_MODE_COMMANDS,
+    *AUDYSSEY_COMMANDS,
+    *DIRAC_COMMANDS,
+    *VOLUME_COMMANDS,
+}
+
+ALL_COMMANDS_DENON = {
+    # Same as ALL_COMMANDS but with STATUS
+    *CORE_COMMANDS_DENON,
+    *SOUND_MODE_COMMANDS,
+    *AUDYSSEY_COMMANDS,
+    *DIRAC_COMMANDS,
+    *VOLUME_COMMANDS,
+}
+
+ALL_COMMANDS_TELNET = {
+    # Same as ALL_COMMANDS but with support for toggle commands
+    *CORE_COMMANDS_TELNET,
+    *SOUND_MODE_COMMANDS_TELNET,
+    *AUDYSSEY_COMMANDS,
+    *DIRAC_COMMANDS,
+    *VOLUME_COMMANDS_TELNET,
+}
+
+ALL_COMMANDS_TELNET_DENON = {
+    # Same as ALL_COMMANDS_TELNET but with support for toggle commands and STATUS
+    *CORE_COMMANDS_DENON_TELNET,
+    *SOUND_MODE_COMMANDS_TELNET,
+    *AUDYSSEY_COMMANDS,
+    *DIRAC_COMMANDS,
+    *VOLUME_COMMANDS_TELNET,
+}
+
+
+# pylint: disable=R0903
+class SimpleCommand:
+    """Handles mapping and sending of Simple Commands to the receiver."""
+
+    def __init__(self, receiver: denonavr.DenonAVR, send_command: Callable[[str], Awaitable[ucapi.StatusCodes | None]]):
+        """
+        Create a SimpleCommand instance.
+
+        :param receiver: Denon receiver instance
+        :param send_command: Function to send a raw command to the receiver
+        """
+        self._receiver = receiver
+        self._send_command = send_command
+
+    async def send_simple_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        """Send a simple command to the AVR."""
+        if cmd in CORE_COMMANDS_DENON_TELNET:
+            return await self._handle_core_command(cmd)
+        if cmd in VOLUME_COMMANDS_TELNET:
+            return await self._handle_volume_command(cmd)
+        if cmd in SOUND_MODE_COMMANDS_TELNET:
+            return await self._handle_sound_mode_command(cmd)
+        if cmd in AUDYSSEY_COMMANDS:
+            return await self._handle_audyssey_command(cmd)
+        if cmd in DIRAC_COMMANDS:
+            return await self._handle_dirac_command(cmd)
+        return ucapi.StatusCodes.NOT_IMPLEMENTED
+
+    async def _handle_core_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        # pylint: disable=R0911
+        match cmd:
+            case "OUTPUT_1":
+                return await self._receiver.async_hdmi_output("HDMI1")
+            case "OUTPUT_2":
+                return await self._receiver.async_hdmi_output("HDMI2")
+            case "OUTPUT_AUTO":
+                return await self._receiver.async_hdmi_output("Auto")
+            case "DIMMER_TOGGLE":
+                return await self._receiver.async_dimmer_toggle()
+            case "DIMMER_BRIGHT":
+                return await self._receiver.async_dimmer("Bright")
+            case "DIMMER_DIM":
+                return await self._receiver.async_dimmer("Dim")
+            case "DIMMER_DARK":
+                return await self._receiver.async_dimmer("Dark")
+            case "DIMMER_OFF":
+                return await self._receiver.async_dimmer("Off")
+            case "TRIGGER1_ON":
+                return await self._receiver.async_trigger_on(1)
+            case "TRIGGER1_OFF":
+                return await self._receiver.async_trigger_off(1)
+            case "TRIGGER2_ON":
+                return await self._receiver.async_trigger_on(2)
+            case "TRIGGER2_OFF":
+                return await self._receiver.async_trigger_off(2)
+            case "TRIGGER3_ON":
+                return await self._receiver.async_trigger_on(3)
+            case "TRIGGER3_OFF":
+                return await self._receiver.async_trigger_off(3)
+            case "DELAY_UP":
+                return await self._receiver.async_delay_up()
+            case "DELAY_DOWN":
+                return await self._receiver.async_delay_down()
+            case "ECO_ON":
+                return await self._receiver.async_eco_mode("On")
+            case "ECO_OFF":
+                return await self._receiver.async_eco_mode("Off")
+            case "ECO_AUTO":
+                return await self._receiver.async_eco_mode("Auto")
+            case "INFO_MENU":
+                return await self._receiver.async_info()
+            case "OPTIONS_MENU":
+                return await self._receiver.async_options()
+            case "CHANNEL_LEVEL_ADJUST_MENU":
+                return await self._receiver.async_channel_level_adjust()
+            case "AUTO_STANDBY_OFF":
+                return await self._receiver.async_auto_standby("OFF")
+            case "AUTO_STANDBY_15MIN":
+                return await self._receiver.async_auto_standby("15M")
+            case "AUTO_STANDBY_30MIN":
+                return await self._receiver.async_auto_standby("30M")
+            case "AUTO_STANDBY_60MIN":
+                return await self._receiver.async_auto_standby("60M")
+            case "DELAY_TIME_UP":
+                return await self._receiver.async_delay_time_up()
+            case "DELAY_TIME_DOWN":
+                return await self._receiver.async_delay_time_down()
+            case "HDMI_AUDIO_DECODE_AMP":
+                return await self._receiver.async_hdmi_audio_decode("AMP")
+            case "HDMI_AUDIO_DECODE_TV":
+                return await self._receiver.async_hdmi_audio_decode("TV")
+            case "VIDEO_PROCESSING_MODE_AUTO":
+                return await self._receiver.async_video_processing_mode("Auto")
+            case "VIDEO_PROCESSING_MODE_GAME":
+                return await self._receiver.async_video_processing_mode("Game")
+            case "VIDEO_PROCESSING_MODE_MOVIE":
+                return await self._receiver.async_video_processing_mode("Movie")
+            case "VIDEO_PROCESSING_MODE_BYPASS":
+                return await self._receiver.async_video_processing_mode("Bypass")
+            case "NETWORK_RESTART":
+                return await self._receiver.async_network_restart()
+            case "SPEAKER_PRESET_1":
+                return await self._receiver.async_speaker_preset(1)
+            case "SPEAKER_PRESET_2":
+                return await self._receiver.async_speaker_preset(2)
+            case "SPEAKER_PRESET_TOGGLE":
+                return await self._receiver.async_speaker_preset_toggle()
+            case "BT_TRANSMITTER_ON":
+                return await self._receiver.async_bt_transmitter_on()
+            case "BT_TRANSMITTER_OFF":
+                return await self._receiver.async_bt_transmitter_off()
+            case "BT_TRANSMITTER_TOGGLE":
+                return await self._receiver.async_bt_transmitter_toggle()
+            case "BT_OUTPUT_MODE_BT_SPEAKER":
+                return await self._receiver.async_bt_output_mode("Bluetooth + Speakers")
+            case "BT_OUTPUT_MODE_BT_ONLY":
+                return await self._receiver.async_bt_output_mode("Bluetooth Only")
+            case "BT_OUTPUT_MODE_TOGGLE":
+                return await self._receiver.async_bt_output_mode_toggle()
+            case "AUDIO_RESTORER_OFF":
+                return await self._receiver.async_audio_restorer("Off")
+            case "AUDIO_RESTORER_LOW":
+                return await self._receiver.async_audio_restorer("Low")
+            case "AUDIO_RESTORER_MEDIUM":
+                return await self._receiver.async_audio_restorer("Medium")
+            case "AUDIO_RESTORER_HIGH":
+                return await self._receiver.async_audio_restorer("High")
+            case "REMOTE_CONTROL_LOCK_ON":
+                return await self._receiver.async_remote_control_lock()
+            case "REMOTE_CONTROL_LOCK_OFF":
+                return await self._receiver.async_remote_control_unlock()
+            case "PANEL_LOCK_PANEL":
+                return await self._receiver.async_panel_lock("Panel")
+            case "PANEL_LOCK_PANEL_VOLUME":
+                return await self._receiver.async_panel_lock("Panel + Master Volume")
+            case "PANEL_LOCK_OFF":
+                return await self._receiver.async_panel_unlock()
+            case "GRAPHIC_EQ_ON":
+                return await self._receiver.async_graphic_eq_on()
+            case "GRAPHIC_EQ_OFF":
+                return await self._receiver.async_graphic_eq_off()
+            case "GRAPHIC_EQ_TOGGLE":
+                return await self._receiver.async_graphic_eq_toggle()
+            case "HEADPHONE_EQ_ON":
+                return await self._receiver.async_headphone_eq_on()
+            case "HEADPHONE_EQ_OFF":
+                return await self._receiver.async_headphone_eq_off()
+            case "HEADPHONE_EQ_TOGGLE":
+                return await self._receiver.async_headphone_eq_toggle()
+            case "STATUS":
+                await self._receiver.async_status()
+                return None
+
+        return ucapi.StatusCodes.BAD_REQUEST
+
+    async def _handle_volume_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        # pylint: disable=R0911
+        match cmd:
+            case "FRONT_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Left")
+            case "FRONT_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Left")
+            case "FRONT_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Right")
+            case "FRONT_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Right")
+            case "CENTER_UP":
+                return await self._receiver.vol.async_channel_volume_up("Center")
+            case "CENTER_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Center")
+            case "SUB_UP":
+                return await self._receiver.vol.async_channel_volume_up("Subwoofer")
+            case "SUB_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Subwoofer")
+            case "SUB2_UP":
+                return await self._receiver.vol.async_channel_volume_up("Subwoofer 2")
+            case "SUB2_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Subwoofer 2")
+            case "SUB3_UP":
+                return await self._receiver.vol.async_channel_volume_up("Subwoofer 3")
+            case "SUB3_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Subwoofer 3")
+            case "SUB4_UP":
+                return await self._receiver.vol.async_channel_volume_up("Subwoofer 4")
+            case "SUB4_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Subwoofer 4")
+            case "SURROUND_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Left")
+            case "SURROUND_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Left")
+            case "SURROUND_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Right")
+            case "SURROUND_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Right")
+            case "SURROUND_BACK_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Back Left")
+            case "SURROUND_BACK_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Back Left")
+            case "SURROUND_BACK_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Back Right")
+            case "SURROUND_BACK_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Back Right")
+            case "FRONT_HEIGHT_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Height Left")
+            case "FRONT_HEIGHT_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Height Left")
+            case "FRONT_HEIGHT_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Height Right")
+            case "FRONT_HEIGHT_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Height Right")
+            case "FRONT_WIDE_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Wide Left")
+            case "FRONT_WIDE_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Wide Left")
+            case "FRONT_WIDE_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Wide Right")
+            case "FRONT_WIDE_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Wide Right")
+            case "TOP_FRONT_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Front Left")
+            case "TOP_FRONT_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Front Left")
+            case "TOP_FRONT_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Front Right")
+            case "TOP_FRONT_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Front Right")
+            case "TOP_MIDDLE_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Middle Left")
+            case "TOP_MIDDLE_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Middle Left")
+            case "TOP_MIDDLE_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Middle Right")
+            case "TOP_MIDDLE_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Middle Right")
+            case "TOP_REAR_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Rear Left")
+            case "TOP_REAR_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Rear Left")
+            case "TOP_REAR_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Rear Right")
+            case "TOP_REAR_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Rear Right")
+            case "REAR_HEIGHT_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Rear Height Left")
+            case "REAR_HEIGHT_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Rear Height Left")
+            case "REAR_HEIGHT_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Rear Height Right")
+            case "REAR_HEIGHT_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Rear Height Right")
+            case "FRONT_DOLBY_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Dolby Left")
+            case "FRONT_DOLBY_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Dolby Left")
+            case "FRONT_DOLBY_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Front Dolby Right")
+            case "FRONT_DOLBY_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Front Dolby Right")
+            case "SURROUND_DOLBY_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Dolby Left")
+            case "SURROUND_DOLBY_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Dolby Left")
+            case "SURROUND_DOLBY_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Dolby Right")
+            case "BACK_DOLBY_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Back Dolby Left")
+            case "BACK_DOLBY_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Back Dolby Left")
+            case "BACK_DOLBY_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Back Dolby Right")
+            case "BACK_DOLBY_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Back Dolby Right")
+            case "SURROUND_HEIGHT_LEFT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Height Left")
+            case "SURROUND_HEIGHT_LEFT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Height Left")
+            case "SURROUND_HEIGHT_RIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Surround Height Right")
+            case "SURROUND_HEIGHT_RIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Surround Height Right")
+            case "TOP_SURROUND_UP":
+                return await self._receiver.vol.async_channel_volume_up("Top Surround")
+            case "TOP_SURROUND_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Top Surround")
+            case "CENTER_HEIGHT_UP":
+                return await self._receiver.vol.async_channel_volume_up("Center Height")
+            case "CENTER_HEIGHT_DOWN":
+                return await self._receiver.vol.async_channel_volume_down("Center Height")
+            case "CHANNEL_VOLUMES_RESET":
+                return await self._receiver.vol.async_channel_volumes_reset()
+            case "SUBWOOFER_ON":
+                return await self._receiver.vol.async_subwoofer_on()
+            case "SUBWOOFER_OFF":
+                return await self._receiver.vol.async_subwoofer_off()
+            case "SUBWOOFER_TOGGLE":
+                return await self._receiver.vol.async_subwoofer_toggle()
+            case "SUBWOOFER_LEVE_UP":
+                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer")
+            case "SUBWOOFER_LEVEL_DOWN":
+                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer")
+            case "SUBWOOFER2_LEVE_UP":
+                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 2")
+            case "SUBWOOFER2_LEVEL_DOWN":
+                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 2")
+            case "SUBWOOFER3_LEVE_UP":
+                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 3")
+            case "SUBWOOFER3_LEVEL_DOWN":
+                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 3")
+            case "SUBWOOFER4_LEVE_UP":
+                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 4")
+            case "SUBWOOFER4_LEVEL_DOWN":
+                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 4")
+            case "LFE_UP":
+                return await self._receiver.vol.async_lfe_up()
+            case "LFE_DOWN":
+                return await self._receiver.vol.async_lfe_down()
+            case "BASS_SYNC_UP":
+                return await self._receiver.vol.async_bass_sync_up()
+            case "BASS_SYNC_DOWN":
+                return await self._receiver.vol.async_bass_sync_down()
+
+    async def _handle_sound_mode_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        # pylint: disable=R0911
+        match cmd:
+            case "SURROUND_MODE_AUTO":
+                return await self._send_command("MSAUTO")
+            case "SURROUND_MODE_DIRECT":
+                return await self._send_command("MSDIRECT")
+            case "SURROUND_MODE_PURE_DIRECT":
+                return await self._send_command("MSPURE DIRECT")
+            case "SURROUND_MODE_DOLBY_DIGITAL":
+                return await self._send_command("MSDOLBY DIGITAL")
+            case "SURROUND_MODE_DTS_SURROUND":
+                return await self._send_command("MSDTS SURROUND")
+            case "SURROUND_MODE_AURO3D":
+                return await self._send_command("MSAURO3D")
+            case "SURROUND_MODE_AURO2DSURR":
+                return await self._send_command("MSAURO2DSURR")
+            case "SURROUND_MODE_MCH_STEREO":
+                return await self._send_command("MSMCH STEREO")
+            case "SURROUND_MODE_NEXT":
+                return await self._receiver.soundmode.async_sound_mode_next()
+            case "SURROUND_MODE_PREVIOUS":
+                return await self._receiver.soundmode.async_sound_mode_previous()
+            case "SOUND_MODE_NEURAL_X_ON":
+                return await self._receiver.soundmode.async_neural_x_on()
+            case "SOUND_MODE_NEURAL_X_OFF":
+                return await self._receiver.soundmode.async_neural_x_off()
+            case "SOUND_MODE_NEURAL_X_TOGGLE":
+                return await self._receiver.soundmode.async_neural_x_toggle()
+            case "SOUND_MODE_IMAX_AUTO":
+                return await self._receiver.soundmode.async_imax_auto()
+            case "SOUND_MODE_IMAX_OFF":
+                return await self._receiver.soundmode.async_imax_off()
+            case "SOUND_MODE_IMAX_TOGGLE":
+                return await self._receiver.soundmode.async_imax_toggle()
+            case "IMAX_AUDIO_SETTINGS_AUTO":
+                return await self._receiver.soundmode.async_imax_audio_settings("AUTO")
+            case "IMAX_AUDIO_SETTINGS_MANUAL":
+                return await self._receiver.soundmode.async_imax_audio_settings("MANUAL")
+            case "IMAX_AUDIO_SETTINGS_TOGGLE":
+                return await self._receiver.soundmode.async_imax_audio_settings_toggle()
+            case "IMAX_SUBWOOFER_ON":
+                return await self._receiver.soundmode.async_imax_subwoofer_mode("ON")
+            case "IMAX_SUBWOOFER_OFF":
+                return await self._receiver.soundmode.async_imax_subwoofer_mode("OFF")
+            case "IMAX_SUBWOOFER_OUTPUT_LFE_MAIN":
+                return await self._receiver.soundmode.async_imax_subwoofer_output("L+M")
+            case "IMAX_SUBWOOFER_OUTPUT_LFE":
+                return await self._receiver.soundmode.async_imax_subwoofer_output("LFE")
+            case "CINEMA_EQ_ON":
+                return await self._receiver.soundmode.async_cinema_eq_on()
+            case "CINEMA_EQ_OFF":
+                return await self._receiver.soundmode.async_cinema_eq_off()
+            case "CINEMA_EQ_TOGGLE":
+                return await self._receiver.soundmode.async_cinema_eq_toggle()
+            case "CENTER_SPREAD_ON":
+                return await self._receiver.soundmode.async_center_spread_on()
+            case "CENTER_SPREAD_OFF":
+                return await self._receiver.soundmode.async_center_spread_off()
+            case "CENTER_SPREAD_TOGGLE":
+                return await self._receiver.soundmode.async_center_spread_toggle()
+            case "LOUDNESS_MANAGEMENT_ON":
+                return await self._receiver.soundmode.async_loudness_management_on()
+            case "LOUDNESS_MANAGEMENT_OFF":
+                return await self._receiver.soundmode.async_loudness_management_off()
+            case "LOUDNESS_MANAGEMENT_TOGGLE":
+                return await self._receiver.soundmode.async_loudness_management_toggle()
+            case "DIALOG_ENHANCER_OFF":
+                return await self._receiver.soundmode.async_dialog_enhancer("Off")
+            case "DIALOG_ENHANCER_LOW":
+                return await self._receiver.soundmode.async_dialog_enhancer("Low")
+            case "DIALOG_ENHANCER_MEDIUM":
+                return await self._receiver.soundmode.async_dialog_enhancer("Medium")
+            case "DIALOG_ENHANCER_HIGH":
+                return await self._receiver.soundmode.async_dialog_enhancer("High")
+            case "AUROMATIC_3D_PRESET_SMALL":
+                return await self._receiver.soundmode.async_auromatic_3d_preset("Small")
+            case "AUROMATIC_3D_PRESET_MEDIUM":
+                return await self._receiver.soundmode.async_auromatic_3d_preset("Medium")
+            case "AUROMATIC_3D_PRESET_LARGE":
+                return await self._receiver.soundmode.async_auromatic_3d_preset("Large")
+            case "AUROMATIC_3D_PRESET_SPEECH":
+                return await self._receiver.soundmode.async_auromatic_3d_preset("Speech")
+            case "AUROMATIC_3D_PRESET_MOVIE":
+                return await self._receiver.soundmode.async_auromatic_3d_preset("Movie")
+            case "AUROMATIC_3D_STRENGTH_UP":
+                return await self._receiver.soundmode.async_auromatic_3d_strength_up()
+            case "AUROMATIC_3D_STRENGTH_DOWN":
+                return await self._receiver.soundmode.async_auromatic_3d_strength_down()
+            case "AURO_3D_MODE_DIRECT":
+                return await self._receiver.soundmode.async_auro_3d_mode("Direct")
+            case "AURO_3D_MODE_CHANNEL_EXPANSION":
+                return await self._receiver.soundmode.async_auro_3d_mode("Channel Expansion")
+            case "DIALOG_CONTROL_UP":
+                return await self._receiver.soundmode.async_dialog_control_up()
+            case "DIALOG_CONTROL_DOWN":
+                return await self._receiver.soundmode.async_dialog_control_down()
+            case "SPEAKER_VIRTUALIZER_ON":
+                return await self._receiver.soundmode.async_speaker_virtualizer_on()
+            case "SPEAKER_VIRTUALIZER_OFF":
+                return await self._receiver.soundmode.async_speaker_virtualizer_off()
+            case "SPEAKER_VIRTUALIZER_TOGGLE":
+                return await self._receiver.soundmode.async_speaker_virtualizer_toggle()
+            case "EFFECT_SPEAKER_SELECTION_FLOOR":
+                return await self._receiver.soundmode.async_effect_speaker_selection("Floor")
+            case "EFFECT_SPEAKER_SELECTION_HEIGHT_FLOOR":
+                return await self._receiver.soundmode.async_effect_speaker_selection("Height + Floor")
+            case "EFFECT_SPEAKER_SELECTION_TOGGLE":
+                return await self._receiver.soundmode.async_effect_speaker_selection_toggle()
+            case "DRC_AUTO":
+                return await self._receiver.soundmode.async_drc("AUTO")
+            case "DRC_LOW":
+                return await self._receiver.soundmode.async_drc("LOW")
+            case "DRC_MID":
+                return await self._receiver.soundmode.async_drc("MID")
+            case "DRC_HI":
+                return await self._receiver.soundmode.async_drc("HI")
+            case "DRC_OFF":
+                return await self._receiver.soundmode.async_drc("OFF")
+
+    async def _handle_audyssey_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        # pylint: disable=R0911
+        match cmd:
+            case "MULTIEQ_REFERENCE":
+                return await self._send_command("PSMULTEQ:AUDYSSEY")
+            case "MULTIEQ_BYPASS_LR":
+                return await self._send_command("PSMULTEQ:BYP.LR")
+            case "MULTIEQ_FLAT":
+                return await self._send_command("PSMULTEQ:FLAT")
+            case "MULTIEQ_OFF":
+                return await self._send_command("PSMULTEQ:OFF")
+            case "DYNAMIC_EQ_ON":
+                return await self._receiver.audyssey.async_dynamiceq_on()
+            case "DYNAMIC_EQ_OFF":
+                return await self._receiver.audyssey.async_dynamiceq_off()
+            case "DYNAMIC_EQ_TOGGLE":
+                return await self._receiver.audyssey.async_toggle_dynamic_eq()
+            case "AUDYSSEY_LFC":
+                return await self._receiver.audyssey.async_lfc_on()
+            case "AUDYSSEY_LFC_OFF":
+                return await self._receiver.audyssey.async_lfc_off()
+            case "DYNAMIC_VOLUME_OFF":
+                return await self._receiver.audyssey.async_set_dynamicvol("Off")
+            case "DYNAMIC_VOLUME_LIGHT":
+                return await self._receiver.audyssey.async_set_dynamicvol("Light")
+            case "DYNAMIC_VOLUME_MEDIUM":
+                return await self._receiver.audyssey.async_set_dynamicvol("Medium")
+            case "DYNAMIC_VOLUME_HEAVY":
+                return await self._receiver.audyssey.async_set_dynamicvol("Heavy")
+            case "CONTAINMENT_AMOUNT_UP":
+                return await self._receiver.audyssey.async_containment_amount_up()
+            case "CONTAINMENT_AMOUNT_DOWN":
+                return await self._receiver.audyssey.async_containment_amount_down()
+
+    async def _handle_dirac_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        # pylint: disable=R0911
+        match cmd:
+            case "DIRAC_LIVE_FILTER_SLOT1":
+                return await self._receiver.dirac.async_dirac_filter("Slot 1")
+            case "DIRAC_LIVE_FILTER_SLOT2":
+                return await self._receiver.dirac.async_dirac_filter("Slot 2")
+            case "DIRAC_LIVE_FILTER_SLOT3":
+                return await self._receiver.dirac.async_dirac_filter("Slot 3")
+            case "DIRAC_LIVE_FILTER_OFF":
+                return await self._receiver.dirac.async_dirac_filter("Off")

--- a/intg-denonavr/simplecommand.py
+++ b/intg-denonavr/simplecommand.py
@@ -100,7 +100,26 @@ SOUND_MODE_COMMANDS = {
     "SOUND_MODE_IMAX_OFF",
     "IMAX_AUDIO_SETTINGS_AUTO",
     "IMAX_AUDIO_SETTINGS_MANUAL",
-    # IMAX HPF and LPF?
+    "IMAX_HPF_40HZ",
+    "IMAX_HPF_60HZ",
+    "IMAX_HPF_80HZ",
+    "IMAX_HPF_90HZ",
+    "IMAX_HPF_100HZ",
+    "IMAX_HPF_110HZ",
+    "IMAX_HPF_120HZ",
+    "IMAX_HPF_150HZ",
+    "IMAX_HPF_180HZ",
+    "IMAX_HPF_200HZ",
+    "IMAX_HPF_250HZ",
+    "IMAX_LPF_80HZ",
+    "IMAX_LPF_90HZ",
+    "IMAX_LPF_100HZ",
+    "IMAX_LPF_110HZ",
+    "IMAX_LPF_120HZ",
+    "IMAX_LPF_150HZ",
+    "IMAX_LPF_180HZ",
+    "IMAX_LPF_200HZ",
+    "IMAX_LPF_250HZ",
     "IMAX_SUBWOOFER_ON",
     "IMAX_SUBWOOFER_OFF",
     "IMAX_SUBWOOFER_OUTPUT_LFE_MAIN",
@@ -129,7 +148,13 @@ SOUND_MODE_COMMANDS = {
     "SPEAKER_VIRTUALIZER_ON",
     "SPEAKER_VIRTUALIZER_OFF",
     "EFFECT_SPEAKER_SELECTION_FLOOR",
+    "EFFECT_SPEAKER_SELECTION_FRONT",
+    "EFFECT_SPEAKER_SELECTION_FRONT_HEIGHT",
+    "EFFECT_SPEAKER_SELECTION_FRONT_WIDE",
     "EFFECT_SPEAKER_SELECTION_HEIGHT_FLOOR",
+    "EFFECT_SPEAKER_SELECTION_SURROUND_BACK",
+    "EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_HEIGHT",
+    "EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_WIDE",
     "DRC_AUTO",
     "DRC_LOW",
     "DRC_MID",
@@ -146,7 +171,6 @@ SOUND_MODE_COMMANDS_TELNET = {
     "CENTER_SPREAD_TOGGLE",
     "LOUDNESS_MANAGEMENT_TOGGLE",
     "SPEAKER_VIRTUALIZER_TOGGLE",
-    "EFFECT_SPEAKER_SELECTION_TOGGLE",
 }
 
 AUDYSSEY_COMMANDS = {
@@ -245,13 +269,13 @@ VOLUME_COMMANDS = {
     "CHANNEL_VOLUMES_RESET",
     "SUBWOOFER_ON",
     "SUBWOOFER_OFF",
-    "SUBWOOFER_LEVE_UP",
-    "SUBWOOFER_LEVEL_DOWN",
-    "SUBWOOFER2_LEVE_UP",
+    "SUBWOOFER1_LEVEL_UP",
+    "SUBWOOFER1_LEVEL_DOWN",
+    "SUBWOOFER2_LEVEL_UP",
     "SUBWOOFER2_LEVEL_DOWN",
-    "SUBWOOFER3_LEVE_UP",
+    "SUBWOOFER3_LEVEL_UP",
     "SUBWOOFER3_LEVEL_DOWN",
-    "SUBWOOFER4_LEVE_UP",
+    "SUBWOOFER4_LEVEL_UP",
     "SUBWOOFER4_LEVEL_DOWN",
     "LFE_UP",
     "LFE_DOWN",
@@ -304,7 +328,7 @@ ALL_COMMANDS_TELNET_DENON = {
 class SimpleCommand:
     """Handles mapping and sending of Simple Commands to the receiver."""
 
-    def __init__(self, receiver: denonavr.DenonAVR, send_command: Callable[[str], Awaitable[ucapi.StatusCodes | None]]):
+    def __init__(self, receiver: denonavr.DenonAVR, send_command: Callable[[str], Awaitable[ucapi.StatusCodes]]):
         """
         Create a SimpleCommand instance.
 
@@ -314,7 +338,7 @@ class SimpleCommand:
         self._receiver = receiver
         self._send_command = send_command
 
-    async def send_simple_command(self, cmd: str) -> ucapi.StatusCodes | None:
+    async def send_simple_command(self, cmd: str) -> ucapi.StatusCodes:
         """Send a simple command to the AVR."""
         if cmd in CORE_COMMANDS_DENON_TELNET:
             return await self._handle_core_command(cmd)
@@ -328,301 +352,306 @@ class SimpleCommand:
             return await self._handle_dirac_command(cmd)
         return ucapi.StatusCodes.NOT_IMPLEMENTED
 
-    async def _handle_core_command(self, cmd: str) -> ucapi.StatusCodes | None:
-        # pylint: disable=R0911
+    async def _handle_core_command(self, cmd: str) -> ucapi.StatusCodes:
+        # pylint: disable=R0915
         match cmd:
             case "OUTPUT_1":
-                return await self._receiver.async_hdmi_output("HDMI1")
+                await self._receiver.async_hdmi_output("HDMI1")
             case "OUTPUT_2":
-                return await self._receiver.async_hdmi_output("HDMI2")
+                await self._receiver.async_hdmi_output("HDMI2")
             case "OUTPUT_AUTO":
-                return await self._receiver.async_hdmi_output("Auto")
+                await self._receiver.async_hdmi_output("Auto")
             case "DIMMER_TOGGLE":
-                return await self._receiver.async_dimmer_toggle()
+                await self._receiver.async_dimmer_toggle()
             case "DIMMER_BRIGHT":
-                return await self._receiver.async_dimmer("Bright")
+                await self._receiver.async_dimmer("Bright")
             case "DIMMER_DIM":
-                return await self._receiver.async_dimmer("Dim")
+                await self._receiver.async_dimmer("Dim")
             case "DIMMER_DARK":
-                return await self._receiver.async_dimmer("Dark")
+                await self._receiver.async_dimmer("Dark")
             case "DIMMER_OFF":
-                return await self._receiver.async_dimmer("Off")
+                await self._receiver.async_dimmer("Off")
             case "TRIGGER1_ON":
-                return await self._receiver.async_trigger_on(1)
+                await self._receiver.async_trigger_on(1)
             case "TRIGGER1_OFF":
-                return await self._receiver.async_trigger_off(1)
+                await self._receiver.async_trigger_off(1)
             case "TRIGGER2_ON":
-                return await self._receiver.async_trigger_on(2)
+                await self._receiver.async_trigger_on(2)
             case "TRIGGER2_OFF":
-                return await self._receiver.async_trigger_off(2)
+                await self._receiver.async_trigger_off(2)
             case "TRIGGER3_ON":
-                return await self._receiver.async_trigger_on(3)
+                await self._receiver.async_trigger_on(3)
             case "TRIGGER3_OFF":
-                return await self._receiver.async_trigger_off(3)
+                await self._receiver.async_trigger_off(3)
             case "DELAY_UP":
-                return await self._receiver.async_delay_up()
+                await self._receiver.async_delay_up()
             case "DELAY_DOWN":
-                return await self._receiver.async_delay_down()
-            case "ECO_ON":
-                return await self._receiver.async_eco_mode("On")
-            case "ECO_OFF":
-                return await self._receiver.async_eco_mode("Off")
+                await self._receiver.async_delay_down()
             case "ECO_AUTO":
-                return await self._receiver.async_eco_mode("Auto")
+                await self._receiver.async_eco_mode("Auto")
+            case "ECO_ON":
+                await self._receiver.async_eco_mode("On")
+            case "ECO_OFF":
+                await self._receiver.async_eco_mode("Off")
             case "INFO_MENU":
-                return await self._receiver.async_info()
+                await self._receiver.async_info()
             case "OPTIONS_MENU":
-                return await self._receiver.async_options()
+                await self._receiver.async_options()
             case "CHANNEL_LEVEL_ADJUST_MENU":
-                return await self._receiver.async_channel_level_adjust()
+                await self._receiver.async_channel_level_adjust()
             case "AUTO_STANDBY_OFF":
-                return await self._receiver.async_auto_standby("OFF")
+                await self._receiver.async_auto_standby("OFF")
             case "AUTO_STANDBY_15MIN":
-                return await self._receiver.async_auto_standby("15M")
+                await self._receiver.async_auto_standby("15M")
             case "AUTO_STANDBY_30MIN":
-                return await self._receiver.async_auto_standby("30M")
+                await self._receiver.async_auto_standby("30M")
             case "AUTO_STANDBY_60MIN":
-                return await self._receiver.async_auto_standby("60M")
+                await self._receiver.async_auto_standby("60M")
             case "DELAY_TIME_UP":
-                return await self._receiver.async_delay_time_up()
+                await self._receiver.async_delay_time_up()
             case "DELAY_TIME_DOWN":
-                return await self._receiver.async_delay_time_down()
+                await self._receiver.async_delay_time_down()
             case "HDMI_AUDIO_DECODE_AMP":
-                return await self._receiver.async_hdmi_audio_decode("AMP")
+                await self._receiver.async_hdmi_audio_decode("AMP")
             case "HDMI_AUDIO_DECODE_TV":
-                return await self._receiver.async_hdmi_audio_decode("TV")
+                await self._receiver.async_hdmi_audio_decode("TV")
             case "VIDEO_PROCESSING_MODE_AUTO":
-                return await self._receiver.async_video_processing_mode("Auto")
+                await self._receiver.async_video_processing_mode("Auto")
             case "VIDEO_PROCESSING_MODE_GAME":
-                return await self._receiver.async_video_processing_mode("Game")
+                await self._receiver.async_video_processing_mode("Game")
             case "VIDEO_PROCESSING_MODE_MOVIE":
-                return await self._receiver.async_video_processing_mode("Movie")
+                await self._receiver.async_video_processing_mode("Movie")
             case "VIDEO_PROCESSING_MODE_BYPASS":
-                return await self._receiver.async_video_processing_mode("Bypass")
+                await self._receiver.async_video_processing_mode("Bypass")
             case "NETWORK_RESTART":
-                return await self._receiver.async_network_restart()
+                await self._receiver.async_network_restart()
             case "SPEAKER_PRESET_1":
-                return await self._receiver.async_speaker_preset(1)
+                await self._receiver.async_speaker_preset(1)
             case "SPEAKER_PRESET_2":
-                return await self._receiver.async_speaker_preset(2)
+                await self._receiver.async_speaker_preset(2)
             case "SPEAKER_PRESET_TOGGLE":
-                return await self._receiver.async_speaker_preset_toggle()
+                await self._receiver.async_speaker_preset_toggle()
             case "BT_TRANSMITTER_ON":
-                return await self._receiver.async_bt_transmitter_on()
+                await self._receiver.async_bt_transmitter_on()
             case "BT_TRANSMITTER_OFF":
-                return await self._receiver.async_bt_transmitter_off()
+                await self._receiver.async_bt_transmitter_off()
             case "BT_TRANSMITTER_TOGGLE":
-                return await self._receiver.async_bt_transmitter_toggle()
+                await self._receiver.async_bt_transmitter_toggle()
             case "BT_OUTPUT_MODE_BT_SPEAKER":
-                return await self._receiver.async_bt_output_mode("Bluetooth + Speakers")
+                await self._receiver.async_bt_output_mode("Bluetooth + Speakers")
             case "BT_OUTPUT_MODE_BT_ONLY":
-                return await self._receiver.async_bt_output_mode("Bluetooth Only")
+                await self._receiver.async_bt_output_mode("Bluetooth Only")
             case "BT_OUTPUT_MODE_TOGGLE":
-                return await self._receiver.async_bt_output_mode_toggle()
+                await self._receiver.async_bt_output_mode_toggle()
             case "AUDIO_RESTORER_OFF":
-                return await self._receiver.async_audio_restorer("Off")
+                await self._receiver.async_audio_restorer("Off")
             case "AUDIO_RESTORER_LOW":
-                return await self._receiver.async_audio_restorer("Low")
+                await self._receiver.async_audio_restorer("Low")
             case "AUDIO_RESTORER_MEDIUM":
-                return await self._receiver.async_audio_restorer("Medium")
+                await self._receiver.async_audio_restorer("Medium")
             case "AUDIO_RESTORER_HIGH":
-                return await self._receiver.async_audio_restorer("High")
+                await self._receiver.async_audio_restorer("High")
             case "REMOTE_CONTROL_LOCK_ON":
-                return await self._receiver.async_remote_control_lock()
+                await self._receiver.async_remote_control_lock()
             case "REMOTE_CONTROL_LOCK_OFF":
-                return await self._receiver.async_remote_control_unlock()
+                await self._receiver.async_remote_control_unlock()
             case "PANEL_LOCK_PANEL":
-                return await self._receiver.async_panel_lock("Panel")
+                await self._receiver.async_panel_lock("Panel")
             case "PANEL_LOCK_PANEL_VOLUME":
-                return await self._receiver.async_panel_lock("Panel + Master Volume")
+                await self._receiver.async_panel_lock("Panel + Master Volume")
             case "PANEL_LOCK_OFF":
-                return await self._receiver.async_panel_unlock()
+                await self._receiver.async_panel_unlock()
             case "GRAPHIC_EQ_ON":
-                return await self._receiver.async_graphic_eq_on()
+                await self._receiver.async_graphic_eq_on()
             case "GRAPHIC_EQ_OFF":
-                return await self._receiver.async_graphic_eq_off()
+                await self._receiver.async_graphic_eq_off()
             case "GRAPHIC_EQ_TOGGLE":
-                return await self._receiver.async_graphic_eq_toggle()
+                await self._receiver.async_graphic_eq_toggle()
             case "HEADPHONE_EQ_ON":
-                return await self._receiver.async_headphone_eq_on()
+                await self._receiver.async_headphone_eq_on()
             case "HEADPHONE_EQ_OFF":
-                return await self._receiver.async_headphone_eq_off()
+                await self._receiver.async_headphone_eq_off()
             case "HEADPHONE_EQ_TOGGLE":
-                return await self._receiver.async_headphone_eq_toggle()
+                await self._receiver.async_headphone_eq_toggle()
             case "STATUS":
                 await self._receiver.async_status()
-                return None
+            case _:
+                return ucapi.StatusCodes.NOT_IMPLEMENTED
 
-        return ucapi.StatusCodes.BAD_REQUEST
+        return ucapi.StatusCodes.OK
 
-    async def _handle_volume_command(self, cmd: str) -> ucapi.StatusCodes | None:
-        # pylint: disable=R0911
+    async def _handle_volume_command(self, cmd: str) -> ucapi.StatusCodes:
+        # pylint: disable=R0915
         match cmd:
             case "FRONT_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Left")
+                await self._receiver.vol.async_channel_volume_up("Front Left")
             case "FRONT_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Left")
+                await self._receiver.vol.async_channel_volume_down("Front Left")
             case "FRONT_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Right")
+                await self._receiver.vol.async_channel_volume_up("Front Right")
             case "FRONT_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Right")
+                await self._receiver.vol.async_channel_volume_down("Front Right")
             case "CENTER_UP":
-                return await self._receiver.vol.async_channel_volume_up("Center")
+                await self._receiver.vol.async_channel_volume_up("Center")
             case "CENTER_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Center")
-            case "SUB_UP":
-                return await self._receiver.vol.async_channel_volume_up("Subwoofer")
-            case "SUB_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Subwoofer")
+                await self._receiver.vol.async_channel_volume_down("Center")
+            case "SUB1_UP":
+                await self._receiver.vol.async_channel_volume_up("Subwoofer")
+            case "SUB1_DOWN":
+                await self._receiver.vol.async_channel_volume_down("Subwoofer")
             case "SUB2_UP":
-                return await self._receiver.vol.async_channel_volume_up("Subwoofer 2")
+                await self._receiver.vol.async_channel_volume_up("Subwoofer 2")
             case "SUB2_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Subwoofer 2")
+                await self._receiver.vol.async_channel_volume_down("Subwoofer 2")
             case "SUB3_UP":
-                return await self._receiver.vol.async_channel_volume_up("Subwoofer 3")
+                await self._receiver.vol.async_channel_volume_up("Subwoofer 3")
             case "SUB3_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Subwoofer 3")
+                await self._receiver.vol.async_channel_volume_down("Subwoofer 3")
             case "SUB4_UP":
-                return await self._receiver.vol.async_channel_volume_up("Subwoofer 4")
+                await self._receiver.vol.async_channel_volume_up("Subwoofer 4")
             case "SUB4_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Subwoofer 4")
+                await self._receiver.vol.async_channel_volume_down("Subwoofer 4")
             case "SURROUND_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Left")
+                await self._receiver.vol.async_channel_volume_up("Surround Left")
             case "SURROUND_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Left")
+                await self._receiver.vol.async_channel_volume_down("Surround Left")
             case "SURROUND_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Right")
+                await self._receiver.vol.async_channel_volume_up("Surround Right")
             case "SURROUND_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Right")
+                await self._receiver.vol.async_channel_volume_down("Surround Right")
             case "SURROUND_BACK_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Back Left")
+                await self._receiver.vol.async_channel_volume_up("Surround Back Left")
             case "SURROUND_BACK_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Back Left")
+                await self._receiver.vol.async_channel_volume_down("Surround Back Left")
             case "SURROUND_BACK_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Back Right")
+                await self._receiver.vol.async_channel_volume_up("Surround Back Right")
             case "SURROUND_BACK_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Back Right")
+                await self._receiver.vol.async_channel_volume_down("Surround Back Right")
             case "FRONT_HEIGHT_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Height Left")
+                await self._receiver.vol.async_channel_volume_up("Front Height Left")
             case "FRONT_HEIGHT_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Height Left")
+                await self._receiver.vol.async_channel_volume_down("Front Height Left")
             case "FRONT_HEIGHT_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Height Right")
+                await self._receiver.vol.async_channel_volume_up("Front Height Right")
             case "FRONT_HEIGHT_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Height Right")
+                await self._receiver.vol.async_channel_volume_down("Front Height Right")
             case "FRONT_WIDE_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Wide Left")
+                await self._receiver.vol.async_channel_volume_up("Front Wide Left")
             case "FRONT_WIDE_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Wide Left")
+                await self._receiver.vol.async_channel_volume_down("Front Wide Left")
             case "FRONT_WIDE_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Wide Right")
+                await self._receiver.vol.async_channel_volume_up("Front Wide Right")
             case "FRONT_WIDE_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Wide Right")
+                await self._receiver.vol.async_channel_volume_down("Front Wide Right")
             case "TOP_FRONT_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Front Left")
+                await self._receiver.vol.async_channel_volume_up("Top Front Left")
             case "TOP_FRONT_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Front Left")
+                await self._receiver.vol.async_channel_volume_down("Top Front Left")
             case "TOP_FRONT_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Front Right")
+                await self._receiver.vol.async_channel_volume_up("Top Front Right")
             case "TOP_FRONT_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Front Right")
+                await self._receiver.vol.async_channel_volume_down("Top Front Right")
             case "TOP_MIDDLE_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Middle Left")
+                await self._receiver.vol.async_channel_volume_up("Top Middle Left")
             case "TOP_MIDDLE_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Middle Left")
+                await self._receiver.vol.async_channel_volume_down("Top Middle Left")
             case "TOP_MIDDLE_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Middle Right")
+                await self._receiver.vol.async_channel_volume_up("Top Middle Right")
             case "TOP_MIDDLE_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Middle Right")
+                await self._receiver.vol.async_channel_volume_down("Top Middle Right")
             case "TOP_REAR_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Rear Left")
+                await self._receiver.vol.async_channel_volume_up("Top Rear Left")
             case "TOP_REAR_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Rear Left")
+                await self._receiver.vol.async_channel_volume_down("Top Rear Left")
             case "TOP_REAR_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Rear Right")
+                await self._receiver.vol.async_channel_volume_up("Top Rear Right")
             case "TOP_REAR_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Rear Right")
+                await self._receiver.vol.async_channel_volume_down("Top Rear Right")
             case "REAR_HEIGHT_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Rear Height Left")
+                await self._receiver.vol.async_channel_volume_up("Rear Height Left")
             case "REAR_HEIGHT_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Rear Height Left")
+                await self._receiver.vol.async_channel_volume_down("Rear Height Left")
             case "REAR_HEIGHT_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Rear Height Right")
+                await self._receiver.vol.async_channel_volume_up("Rear Height Right")
             case "REAR_HEIGHT_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Rear Height Right")
+                await self._receiver.vol.async_channel_volume_down("Rear Height Right")
             case "FRONT_DOLBY_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Dolby Left")
+                await self._receiver.vol.async_channel_volume_up("Front Dolby Left")
             case "FRONT_DOLBY_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Dolby Left")
+                await self._receiver.vol.async_channel_volume_down("Front Dolby Left")
             case "FRONT_DOLBY_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Front Dolby Right")
+                await self._receiver.vol.async_channel_volume_up("Front Dolby Right")
             case "FRONT_DOLBY_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Front Dolby Right")
+                await self._receiver.vol.async_channel_volume_down("Front Dolby Right")
             case "SURROUND_DOLBY_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Dolby Left")
+                await self._receiver.vol.async_channel_volume_up("Surround Dolby Left")
             case "SURROUND_DOLBY_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Dolby Left")
+                await self._receiver.vol.async_channel_volume_down("Surround Dolby Left")
             case "SURROUND_DOLBY_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Dolby Right")
+                await self._receiver.vol.async_channel_volume_up("Surround Dolby Right")
             case "BACK_DOLBY_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Back Dolby Left")
+                await self._receiver.vol.async_channel_volume_up("Back Dolby Left")
             case "BACK_DOLBY_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Back Dolby Left")
+                await self._receiver.vol.async_channel_volume_down("Back Dolby Left")
             case "BACK_DOLBY_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Back Dolby Right")
+                await self._receiver.vol.async_channel_volume_up("Back Dolby Right")
             case "BACK_DOLBY_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Back Dolby Right")
+                await self._receiver.vol.async_channel_volume_down("Back Dolby Right")
             case "SURROUND_HEIGHT_LEFT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Height Left")
+                await self._receiver.vol.async_channel_volume_up("Surround Height Left")
             case "SURROUND_HEIGHT_LEFT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Height Left")
+                await self._receiver.vol.async_channel_volume_down("Surround Height Left")
             case "SURROUND_HEIGHT_RIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Surround Height Right")
+                await self._receiver.vol.async_channel_volume_up("Surround Height Right")
             case "SURROUND_HEIGHT_RIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Surround Height Right")
+                await self._receiver.vol.async_channel_volume_down("Surround Height Right")
             case "TOP_SURROUND_UP":
-                return await self._receiver.vol.async_channel_volume_up("Top Surround")
+                await self._receiver.vol.async_channel_volume_up("Top Surround")
             case "TOP_SURROUND_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Top Surround")
+                await self._receiver.vol.async_channel_volume_down("Top Surround")
             case "CENTER_HEIGHT_UP":
-                return await self._receiver.vol.async_channel_volume_up("Center Height")
+                await self._receiver.vol.async_channel_volume_up("Center Height")
             case "CENTER_HEIGHT_DOWN":
-                return await self._receiver.vol.async_channel_volume_down("Center Height")
+                await self._receiver.vol.async_channel_volume_down("Center Height")
             case "CHANNEL_VOLUMES_RESET":
-                return await self._receiver.vol.async_channel_volumes_reset()
+                await self._receiver.vol.async_channel_volumes_reset()
             case "SUBWOOFER_ON":
-                return await self._receiver.vol.async_subwoofer_on()
+                await self._receiver.vol.async_subwoofer_on()
             case "SUBWOOFER_OFF":
-                return await self._receiver.vol.async_subwoofer_off()
+                await self._receiver.vol.async_subwoofer_off()
             case "SUBWOOFER_TOGGLE":
-                return await self._receiver.vol.async_subwoofer_toggle()
-            case "SUBWOOFER_LEVE_UP":
-                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer")
-            case "SUBWOOFER_LEVEL_DOWN":
-                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer")
-            case "SUBWOOFER2_LEVE_UP":
-                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 2")
+                await self._receiver.vol.async_subwoofer_toggle()
+            case "SUBWOOFER1_LEVEL_UP":
+                await self._receiver.vol.async_subwoofer_level_up("Subwoofer")
+            case "SUBWOOFER1_LEVEL_DOWN":
+                await self._receiver.vol.async_subwoofer_level_down("Subwoofer")
+            case "SUBWOOFER2_LEVEL_UP":
+                await self._receiver.vol.async_subwoofer_level_up("Subwoofer 2")
             case "SUBWOOFER2_LEVEL_DOWN":
-                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 2")
-            case "SUBWOOFER3_LEVE_UP":
-                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 3")
+                await self._receiver.vol.async_subwoofer_level_down("Subwoofer 2")
+            case "SUBWOOFER3_LEVEL_UP":
+                await self._receiver.vol.async_subwoofer_level_up("Subwoofer 3")
             case "SUBWOOFER3_LEVEL_DOWN":
-                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 3")
-            case "SUBWOOFER4_LEVE_UP":
-                return await self._receiver.vol.async_subwoofer_level_up("Subwoofer 4")
+                await self._receiver.vol.async_subwoofer_level_down("Subwoofer 3")
+            case "SUBWOOFER4_LEVEL_UP":
+                await self._receiver.vol.async_subwoofer_level_up("Subwoofer 4")
             case "SUBWOOFER4_LEVEL_DOWN":
-                return await self._receiver.vol.async_subwoofer_level_down("Subwoofer 4")
+                await self._receiver.vol.async_subwoofer_level_down("Subwoofer 4")
             case "LFE_UP":
-                return await self._receiver.vol.async_lfe_up()
+                await self._receiver.vol.async_lfe_up()
             case "LFE_DOWN":
-                return await self._receiver.vol.async_lfe_down()
+                await self._receiver.vol.async_lfe_down()
             case "BASS_SYNC_UP":
-                return await self._receiver.vol.async_bass_sync_up()
+                await self._receiver.vol.async_bass_sync_up()
             case "BASS_SYNC_DOWN":
-                return await self._receiver.vol.async_bass_sync_down()
+                await self._receiver.vol.async_bass_sync_down()
+            case _:
+                return ucapi.StatusCodes.NOT_IMPLEMENTED
 
-    async def _handle_sound_mode_command(self, cmd: str) -> ucapi.StatusCodes | None:
-        # pylint: disable=R0911
+        return ucapi.StatusCodes.OK
+
+    async def _handle_sound_mode_command(self, cmd: str) -> ucapi.StatusCodes:
+        # pylint: disable=R0915, R0911
         match cmd:
             case "SURROUND_MODE_AUTO":
                 return await self._send_command("MSAUTO")
@@ -641,107 +670,163 @@ class SimpleCommand:
             case "SURROUND_MODE_MCH_STEREO":
                 return await self._send_command("MSMCH STEREO")
             case "SURROUND_MODE_NEXT":
-                return await self._receiver.soundmode.async_sound_mode_next()
+                await self._receiver.soundmode.async_sound_mode_next()
             case "SURROUND_MODE_PREVIOUS":
-                return await self._receiver.soundmode.async_sound_mode_previous()
+                await self._receiver.soundmode.async_sound_mode_previous()
             case "SOUND_MODE_NEURAL_X_ON":
-                return await self._receiver.soundmode.async_neural_x_on()
+                await self._receiver.soundmode.async_neural_x_on()
             case "SOUND_MODE_NEURAL_X_OFF":
-                return await self._receiver.soundmode.async_neural_x_off()
+                await self._receiver.soundmode.async_neural_x_off()
             case "SOUND_MODE_NEURAL_X_TOGGLE":
-                return await self._receiver.soundmode.async_neural_x_toggle()
+                await self._receiver.soundmode.async_neural_x_toggle()
             case "SOUND_MODE_IMAX_AUTO":
-                return await self._receiver.soundmode.async_imax_auto()
+                await self._receiver.soundmode.async_imax_auto()
             case "SOUND_MODE_IMAX_OFF":
-                return await self._receiver.soundmode.async_imax_off()
+                await self._receiver.soundmode.async_imax_off()
             case "SOUND_MODE_IMAX_TOGGLE":
-                return await self._receiver.soundmode.async_imax_toggle()
+                await self._receiver.soundmode.async_imax_toggle()
             case "IMAX_AUDIO_SETTINGS_AUTO":
-                return await self._receiver.soundmode.async_imax_audio_settings("AUTO")
+                await self._receiver.soundmode.async_imax_audio_settings("AUTO")
             case "IMAX_AUDIO_SETTINGS_MANUAL":
-                return await self._receiver.soundmode.async_imax_audio_settings("MANUAL")
+                await self._receiver.soundmode.async_imax_audio_settings("MANUAL")
             case "IMAX_AUDIO_SETTINGS_TOGGLE":
-                return await self._receiver.soundmode.async_imax_audio_settings_toggle()
+                await self._receiver.soundmode.async_imax_audio_settings_toggle()
+            case "IMAX_HPF_40HZ":
+                await self._receiver.soundmode.async_imax_hpf("40")
+            case "IMAX_HPF_60HZ":
+                await self._receiver.soundmode.async_imax_hpf("60")
+            case "IMAX_HPF_80HZ":
+                await self._receiver.soundmode.async_imax_hpf("80")
+            case "IMAX_HPF_90HZ":
+                await self._receiver.soundmode.async_imax_hpf("90")
+            case "IMAX_HPF_100HZ":
+                await self._receiver.soundmode.async_imax_hpf("100")
+            case "IMAX_HPF_110HZ":
+                await self._receiver.soundmode.async_imax_hpf("110")
+            case "IMAX_HPF_120HZ":
+                await self._receiver.soundmode.async_imax_hpf("120")
+            case "IMAX_HPF_150HZ":
+                await self._receiver.soundmode.async_imax_hpf("150")
+            case "IMAX_HPF_180HZ":
+                await self._receiver.soundmode.async_imax_hpf("180")
+            case "IMAX_HPF_200HZ":
+                await self._receiver.soundmode.async_imax_hpf("200")
+            case "IMAX_HPF_250HZ":
+                await self._receiver.soundmode.async_imax_hpf("250")
+            case "IMAX_LPF_80HZ":
+                await self._receiver.soundmode.async_imax_lpf("80")
+            case "IMAX_LPF_90HZ":
+                await self._receiver.soundmode.async_imax_lpf("90")
+            case "IMAX_LPF_100HZ":
+                await self._receiver.soundmode.async_imax_lpf("100")
+            case "IMAX_LPF_110HZ":
+                await self._receiver.soundmode.async_imax_lpf("110")
+            case "IMAX_LPF_120HZ":
+                await self._receiver.soundmode.async_imax_lpf("120")
+            case "IMAX_LPF_150HZ":
+                await self._receiver.soundmode.async_imax_lpf("150")
+            case "IMAX_LPF_180HZ":
+                await self._receiver.soundmode.async_imax_lpf("180")
+            case "IMAX_LPF_200HZ":
+                await self._receiver.soundmode.async_imax_lpf("200")
+            case "IMAX_LPF_250HZ":
+                await self._receiver.soundmode.async_imax_lpf("250")
             case "IMAX_SUBWOOFER_ON":
-                return await self._receiver.soundmode.async_imax_subwoofer_mode("ON")
+                await self._receiver.soundmode.async_imax_subwoofer_mode("ON")
             case "IMAX_SUBWOOFER_OFF":
-                return await self._receiver.soundmode.async_imax_subwoofer_mode("OFF")
+                await self._receiver.soundmode.async_imax_subwoofer_mode("OFF")
             case "IMAX_SUBWOOFER_OUTPUT_LFE_MAIN":
-                return await self._receiver.soundmode.async_imax_subwoofer_output("L+M")
+                await self._receiver.soundmode.async_imax_subwoofer_output("L+M")
             case "IMAX_SUBWOOFER_OUTPUT_LFE":
-                return await self._receiver.soundmode.async_imax_subwoofer_output("LFE")
+                await self._receiver.soundmode.async_imax_subwoofer_output("LFE")
             case "CINEMA_EQ_ON":
-                return await self._receiver.soundmode.async_cinema_eq_on()
+                await self._receiver.soundmode.async_cinema_eq_on()
             case "CINEMA_EQ_OFF":
-                return await self._receiver.soundmode.async_cinema_eq_off()
+                await self._receiver.soundmode.async_cinema_eq_off()
             case "CINEMA_EQ_TOGGLE":
-                return await self._receiver.soundmode.async_cinema_eq_toggle()
+                await self._receiver.soundmode.async_cinema_eq_toggle()
             case "CENTER_SPREAD_ON":
-                return await self._receiver.soundmode.async_center_spread_on()
+                await self._receiver.soundmode.async_center_spread_on()
             case "CENTER_SPREAD_OFF":
-                return await self._receiver.soundmode.async_center_spread_off()
+                await self._receiver.soundmode.async_center_spread_off()
             case "CENTER_SPREAD_TOGGLE":
-                return await self._receiver.soundmode.async_center_spread_toggle()
+                await self._receiver.soundmode.async_center_spread_toggle()
             case "LOUDNESS_MANAGEMENT_ON":
-                return await self._receiver.soundmode.async_loudness_management_on()
+                await self._receiver.soundmode.async_loudness_management_on()
             case "LOUDNESS_MANAGEMENT_OFF":
-                return await self._receiver.soundmode.async_loudness_management_off()
+                await self._receiver.soundmode.async_loudness_management_off()
             case "LOUDNESS_MANAGEMENT_TOGGLE":
-                return await self._receiver.soundmode.async_loudness_management_toggle()
+                await self._receiver.soundmode.async_loudness_management_toggle()
             case "DIALOG_ENHANCER_OFF":
-                return await self._receiver.soundmode.async_dialog_enhancer("Off")
+                await self._receiver.soundmode.async_dialog_enhancer("Off")
             case "DIALOG_ENHANCER_LOW":
-                return await self._receiver.soundmode.async_dialog_enhancer("Low")
+                await self._receiver.soundmode.async_dialog_enhancer("Low")
             case "DIALOG_ENHANCER_MEDIUM":
-                return await self._receiver.soundmode.async_dialog_enhancer("Medium")
+                await self._receiver.soundmode.async_dialog_enhancer("Medium")
             case "DIALOG_ENHANCER_HIGH":
-                return await self._receiver.soundmode.async_dialog_enhancer("High")
+                await self._receiver.soundmode.async_dialog_enhancer("High")
             case "AUROMATIC_3D_PRESET_SMALL":
-                return await self._receiver.soundmode.async_auromatic_3d_preset("Small")
+                await self._receiver.soundmode.async_auromatic_3d_preset("Small")
             case "AUROMATIC_3D_PRESET_MEDIUM":
-                return await self._receiver.soundmode.async_auromatic_3d_preset("Medium")
+                await self._receiver.soundmode.async_auromatic_3d_preset("Medium")
             case "AUROMATIC_3D_PRESET_LARGE":
-                return await self._receiver.soundmode.async_auromatic_3d_preset("Large")
+                await self._receiver.soundmode.async_auromatic_3d_preset("Large")
             case "AUROMATIC_3D_PRESET_SPEECH":
-                return await self._receiver.soundmode.async_auromatic_3d_preset("Speech")
+                await self._receiver.soundmode.async_auromatic_3d_preset("Speech")
             case "AUROMATIC_3D_PRESET_MOVIE":
-                return await self._receiver.soundmode.async_auromatic_3d_preset("Movie")
+                await self._receiver.soundmode.async_auromatic_3d_preset("Movie")
             case "AUROMATIC_3D_STRENGTH_UP":
-                return await self._receiver.soundmode.async_auromatic_3d_strength_up()
+                await self._receiver.soundmode.async_auromatic_3d_strength_up()
             case "AUROMATIC_3D_STRENGTH_DOWN":
-                return await self._receiver.soundmode.async_auromatic_3d_strength_down()
+                await self._receiver.soundmode.async_auromatic_3d_strength_down()
             case "AURO_3D_MODE_DIRECT":
-                return await self._receiver.soundmode.async_auro_3d_mode("Direct")
+                await self._receiver.soundmode.async_auro_3d_mode("Direct")
             case "AURO_3D_MODE_CHANNEL_EXPANSION":
-                return await self._receiver.soundmode.async_auro_3d_mode("Channel Expansion")
+                await self._receiver.soundmode.async_auro_3d_mode("Channel Expansion")
             case "DIALOG_CONTROL_UP":
-                return await self._receiver.soundmode.async_dialog_control_up()
+                await self._receiver.soundmode.async_dialog_control_up()
             case "DIALOG_CONTROL_DOWN":
-                return await self._receiver.soundmode.async_dialog_control_down()
+                await self._receiver.soundmode.async_dialog_control_down()
             case "SPEAKER_VIRTUALIZER_ON":
-                return await self._receiver.soundmode.async_speaker_virtualizer_on()
+                await self._receiver.soundmode.async_speaker_virtualizer_on()
             case "SPEAKER_VIRTUALIZER_OFF":
-                return await self._receiver.soundmode.async_speaker_virtualizer_off()
+                await self._receiver.soundmode.async_speaker_virtualizer_off()
             case "SPEAKER_VIRTUALIZER_TOGGLE":
-                return await self._receiver.soundmode.async_speaker_virtualizer_toggle()
+                await self._receiver.soundmode.async_speaker_virtualizer_toggle()
             case "EFFECT_SPEAKER_SELECTION_FLOOR":
-                return await self._receiver.soundmode.async_effect_speaker_selection("Floor")
+                await self._receiver.soundmode.async_effect_speaker_selection("Floor")
+            case "EFFECT_SPEAKER_SELECTION_FRONT":
+                await self._receiver.soundmode.async_effect_speaker_selection("Front")
+            case "EFFECT_SPEAKER_SELECTION_FRONT_HEIGHT":
+                await self._receiver.soundmode.async_effect_speaker_selection("Front Height")
+            case "EFFECT_SPEAKER_SELECTION_FRONT_HEIGHT_WIDE":
+                await self._receiver.soundmode.async_effect_speaker_selection("Front Height + Front Wide")
+            case "EFFECT_SPEAKER_SELECTION_FRONT_WIDE":
+                await self._receiver.soundmode.async_effect_speaker_selection("Front Wide")
             case "EFFECT_SPEAKER_SELECTION_HEIGHT_FLOOR":
-                return await self._receiver.soundmode.async_effect_speaker_selection("Height + Floor")
-            case "EFFECT_SPEAKER_SELECTION_TOGGLE":
-                return await self._receiver.soundmode.async_effect_speaker_selection_toggle()
+                await self._receiver.soundmode.async_effect_speaker_selection("Height + Floor")
+            case "EFFECT_SPEAKER_SELECTION_SURROUND_BACK":
+                await self._receiver.soundmode.async_effect_speaker_selection("Surround Back")
+            case "EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_HEIGHT":
+                await self._receiver.soundmode.async_effect_speaker_selection("Surround Back + Front Height")
+            case "EFFECT_SPEAKER_SELECTION_SURROUND_BACK_FRONT_WIDE":
+                await self._receiver.soundmode.async_effect_speaker_selection("Surround Back + Front Wide")
             case "DRC_AUTO":
-                return await self._receiver.soundmode.async_drc("AUTO")
+                await self._receiver.soundmode.async_drc("AUTO")
             case "DRC_LOW":
-                return await self._receiver.soundmode.async_drc("LOW")
+                await self._receiver.soundmode.async_drc("LOW")
             case "DRC_MID":
-                return await self._receiver.soundmode.async_drc("MID")
+                await self._receiver.soundmode.async_drc("MID")
             case "DRC_HI":
-                return await self._receiver.soundmode.async_drc("HI")
+                await self._receiver.soundmode.async_drc("HI")
             case "DRC_OFF":
-                return await self._receiver.soundmode.async_drc("OFF")
+                await self._receiver.soundmode.async_drc("OFF")
+            case _:
+                return ucapi.StatusCodes.NOT_IMPLEMENTED
 
-    async def _handle_audyssey_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        return ucapi.StatusCodes.OK
+
+    async def _handle_audyssey_command(self, cmd: str) -> ucapi.StatusCodes:
         # pylint: disable=R0911
         match cmd:
             case "MULTIEQ_REFERENCE":
@@ -753,36 +838,44 @@ class SimpleCommand:
             case "MULTIEQ_OFF":
                 return await self._send_command("PSMULTEQ:OFF")
             case "DYNAMIC_EQ_ON":
-                return await self._receiver.audyssey.async_dynamiceq_on()
+                await self._receiver.audyssey.async_dynamiceq_on()
             case "DYNAMIC_EQ_OFF":
-                return await self._receiver.audyssey.async_dynamiceq_off()
+                await self._receiver.audyssey.async_dynamiceq_off()
             case "DYNAMIC_EQ_TOGGLE":
-                return await self._receiver.audyssey.async_toggle_dynamic_eq()
+                await self._receiver.audyssey.async_toggle_dynamic_eq()
             case "AUDYSSEY_LFC":
-                return await self._receiver.audyssey.async_lfc_on()
+                await self._receiver.audyssey.async_lfc_on()
             case "AUDYSSEY_LFC_OFF":
-                return await self._receiver.audyssey.async_lfc_off()
+                await self._receiver.audyssey.async_lfc_off()
             case "DYNAMIC_VOLUME_OFF":
-                return await self._receiver.audyssey.async_set_dynamicvol("Off")
+                await self._receiver.audyssey.async_set_dynamicvol("Off")
             case "DYNAMIC_VOLUME_LIGHT":
-                return await self._receiver.audyssey.async_set_dynamicvol("Light")
+                await self._receiver.audyssey.async_set_dynamicvol("Light")
             case "DYNAMIC_VOLUME_MEDIUM":
-                return await self._receiver.audyssey.async_set_dynamicvol("Medium")
+                await self._receiver.audyssey.async_set_dynamicvol("Medium")
             case "DYNAMIC_VOLUME_HEAVY":
-                return await self._receiver.audyssey.async_set_dynamicvol("Heavy")
+                await self._receiver.audyssey.async_set_dynamicvol("Heavy")
             case "CONTAINMENT_AMOUNT_UP":
-                return await self._receiver.audyssey.async_containment_amount_up()
+                await self._receiver.audyssey.async_containment_amount_up()
             case "CONTAINMENT_AMOUNT_DOWN":
-                return await self._receiver.audyssey.async_containment_amount_down()
+                await self._receiver.audyssey.async_containment_amount_down()
+            case _:
+                return ucapi.StatusCodes.NOT_IMPLEMENTED
 
-    async def _handle_dirac_command(self, cmd: str) -> ucapi.StatusCodes | None:
+        return ucapi.StatusCodes.OK
+
+    async def _handle_dirac_command(self, cmd: str) -> ucapi.StatusCodes:
         # pylint: disable=R0911
         match cmd:
             case "DIRAC_LIVE_FILTER_SLOT1":
-                return await self._receiver.dirac.async_dirac_filter("Slot 1")
+                await self._receiver.dirac.async_dirac_filter("Slot 1")
             case "DIRAC_LIVE_FILTER_SLOT2":
-                return await self._receiver.dirac.async_dirac_filter("Slot 2")
+                await self._receiver.dirac.async_dirac_filter("Slot 2")
             case "DIRAC_LIVE_FILTER_SLOT3":
-                return await self._receiver.dirac.async_dirac_filter("Slot 3")
+                await self._receiver.dirac.async_dirac_filter("Slot 3")
             case "DIRAC_LIVE_FILTER_OFF":
-                return await self._receiver.dirac.async_dirac_filter("Off")
+                await self._receiver.dirac.async_dirac_filter("Off")
+            case _:
+                return ucapi.StatusCodes.NOT_IMPLEMENTED
+
+        return ucapi.StatusCodes.OK

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyee~=12.1.1
-denonavr~=1.0.1
+denonavr~=1.1.0
 ucapi==0.3.0


### PR DESCRIPTION
- Removes the support for hybrid connections - no longer needed with the changes in the upstream
- Removes wait for ack on commands that don't send them
- Fixes menu state to enable settings menu toggle (telnet only)

Additional commands:

__Audyssey__
- LFC
- Containment Amount

__DenonAVR__
- Improved Settings Menu toggle
- Dimmer
- Auto Standby
- Sleep
- Delay and Delay Time
- Eco Mode
- HDMI Output
- HDMI Audio Decode
- Video Processing Mode
- Tactile Transducer
- Room Size
- Triggers
- Speaker Preset
- Bluetooth Transmitter and Output Mode
- Audio Restorer
- Status Display (Denon only)
- System Reset
- Network Restart
- Remote Control and Panel Lock
- Quick Select and Quick Select Memory (programs a Quick Select)

__Dirac__
- Dirac Filter

__Sound Mode__
- Sound Mode Next/Previous
- Neural:X Toggle
- IMAX Toggle
- IMAX Audio Settings Toggle
- IMAX Low and High Pass Filter
- IMAX Subwoofer Output Mode
- Cinema EQ Toggle
- Center Spread Toggle
- Loudness Management Toggle
- Dialog Enhancer
- Auro-Matic 3D Preset
- Auro-Matic 3D Strength
- Auro 3D mode
- Dialog Control
- Speaker Virtualizer
- Effect Speaker Selection

__Volume__
- Channel Volumes
- Reset All Channel Volumes
- Subwoofer On/Off
- Subwoofer Level
- LFE Volume
- Bass Sync