### PR TITLE
Fix mix up of time units

### DIFF
--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -38,7 +38,7 @@ from ucapi.media_player import Attributes as MediaAttr
 
 _LOG = logging.getLogger(__name__)
 
-SETUP_TIMEOUT = 5000.0
+SETUP_TIMEOUT = 5000
 
 BACKOFF_MAX: float = 30
 MIN_RECONNECT_DELAY: float = 0.5

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -38,7 +38,7 @@ from ucapi.media_player import Attributes as MediaAttr
 
 _LOG = logging.getLogger(__name__)
 
-SETUP_TIMEOUT = 5
+SETUP_TIMEOUT = 5000.0
 
 BACKOFF_MAX: float = 30
 MIN_RECONNECT_DELAY: float = 0.5
@@ -208,7 +208,10 @@ class DenonDevice:
         if device.zone3:
             self._zones["Zone3"] = None
         self._receiver: denonavr.DenonAVR = denonavr.DenonAVR(
-            host=device.address, show_all_inputs=device.show_all_inputs, timeout=device.timeout, add_zones=self._zones
+            host=device.address,
+            show_all_inputs=device.show_all_inputs,
+            timeout=device.timeout / 1000.0,
+            add_zones=self._zones,
         )
         self._update_audyssey = device.update_audyssey
         self._simple_command = SimpleCommand(self._receiver, self._send_command)

--- a/intg-denonavr/config.py
+++ b/intg-denonavr/config.py
@@ -50,7 +50,7 @@ class AvrDevice:
     zone2: bool
     zone3: bool
     volume_step: float
-    timeout: float
+    timeout: int
 
 
 class _EnhancedJSONEncoder(json.JSONEncoder):
@@ -205,7 +205,7 @@ class Devices:
                     item.get("zone2", False),
                     item.get("zone3", False),
                     item.get("volume_step", 0.5),
-                    item.get("timeout", 2000.0),
+                    item.get("timeout", 2000),
                 )
                 needs_migration |= item.get("use_telnet_for_events") is not None
                 self._config.append(avr)

--- a/intg-denonavr/config.py
+++ b/intg-denonavr/config.py
@@ -50,7 +50,7 @@ class AvrDevice:
     zone2: bool
     zone3: bool
     volume_step: float
-    timeout: int
+    timeout: float
 
 
 class _EnhancedJSONEncoder(json.JSONEncoder):
@@ -192,6 +192,12 @@ class Devices:
             needs_migration = False
             for item in data:
                 # not using AvrDevice(**item) to be able to migrate old configuration files with missing attributes
+                timeout = item.get("timeout", 2.0)
+                if timeout > 10.0:
+                    # temp fix due to misunderstood time unit :(
+                    timeout = 2
+                    needs_migration = True
+
                 avr = AvrDevice(
                     item.get("id"),
                     item.get("name"),
@@ -205,7 +211,7 @@ class Devices:
                     item.get("zone2", False),
                     item.get("zone3", False),
                     item.get("volume_step", 0.5),
-                    item.get("timeout", 2000),
+                    timeout,
                 )
                 needs_migration |= item.get("use_telnet_for_events") is not None
                 self._config.append(avr)

--- a/intg-denonavr/config.py
+++ b/intg-denonavr/config.py
@@ -192,12 +192,6 @@ class Devices:
             needs_migration = False
             for item in data:
                 # not using AvrDevice(**item) to be able to migrate old configuration files with missing attributes
-                timeout = item.get("timeout", 2.0)
-                if timeout > 10.0:
-                    # temp fix due to misunderstood time unit :(
-                    timeout = 2
-                    needs_migration = True
-
                 avr = AvrDevice(
                     item.get("id"),
                     item.get("name"),
@@ -211,7 +205,7 @@ class Devices:
                     item.get("zone2", False),
                     item.get("zone3", False),
                     item.get("volume_step", 0.5),
-                    timeout,
+                    item.get("timeout", 2000.0),
                 )
                 needs_migration |= item.get("use_telnet_for_events") is not None
                 self._config.append(avr)

--- a/intg-denonavr/receiver.py
+++ b/intg-denonavr/receiver.py
@@ -23,7 +23,7 @@ class ConnectDenonAVR:
     def __init__(
         self,
         host: str,
-        timeout: float,
+        timeout: int,
         show_all_inputs: bool,
         zone2: bool,
         zone3: bool,

--- a/intg-denonavr/receiver.py
+++ b/intg-denonavr/receiver.py
@@ -86,7 +86,7 @@ class ConnectDenonAVR:
         receiver = DenonAVR(
             host=self._host,
             show_all_inputs=self._show_all_inputs,
-            timeout=self._timeout,
+            timeout=self._timeout / 1000.0,
             add_zones=self._zones,
         )
         await receiver.async_setup()

--- a/intg-denonavr/setup_flow.py
+++ b/intg-denonavr/setup_flow.py
@@ -304,7 +304,7 @@ async def handle_configuration_mode(
             else:
                 connection_mode = "use_http"
             volume_step = selected_device.volume_step if selected_device.volume_step else 0.5
-            timeout = selected_device.timeout if selected_device.timeout else 2000
+            timeout = selected_device.timeout if selected_device.timeout else 2.0
 
             return RequestUserInput(
                 _a("Configure your AVR"),
@@ -427,7 +427,7 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
             # },
             __connection_mode_cfg("use_telnet"),
             __volume_cfg(1),
-            __timeout_cfg(2000),
+            __timeout_cfg(2.0),
             __telnet_info(),
         ],
     )
@@ -458,7 +458,7 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
     except ValueError:
         return SetupError(error_type=IntegrationSetupError.OTHER)
 
-    timeout = int(msg.input_values.get("timeout", 2000))
+    timeout = int(msg.input_values.get("timeout", 2.0))
 
     # Telnet connection isn't required for connection check and retrieving model information
     connect_denonavr = ConnectDenonAVR(
@@ -541,7 +541,7 @@ async def _handle_device_reconfigure(
     _reconfigured_device.zone3 = msg.input_values.get("zone3") == "true"
     _reconfigured_device.use_telnet = connection_mode == "use_telnet"
     _reconfigured_device.volume_step = volume_step
-    _reconfigured_device.timeout = int(msg.input_values.get("timeout", 2000))
+    _reconfigured_device.timeout = float(msg.input_values.get("timeout", 2.0))
 
     config.devices.update(_reconfigured_device)  # triggers receiver instance update
     await asyncio.sleep(1)
@@ -588,11 +588,11 @@ def __volume_cfg(step: float):
     }
 
 
-def __timeout_cfg(timeout: int):
+def __timeout_cfg(timeout: float):
     return {
         "id": "timeout",
         "label": _a("Connection and request timeout"),
         "field": {
-            "number": {"value": timeout, "min": 250, "max": 10000, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
+            "number": {"value": timeout, "min": 0.250, "max": 10.0, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
         },
     }

--- a/intg-denonavr/setup_flow.py
+++ b/intg-denonavr/setup_flow.py
@@ -304,7 +304,7 @@ async def handle_configuration_mode(
             else:
                 connection_mode = "use_http"
             volume_step = selected_device.volume_step if selected_device.volume_step else 0.5
-            timeout = selected_device.timeout if selected_device.timeout else 2000.0
+            timeout = selected_device.timeout if selected_device.timeout else 2000
 
             return RequestUserInput(
                 _a("Configure your AVR"),
@@ -427,7 +427,7 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
             # },
             __connection_mode_cfg("use_telnet"),
             __volume_cfg(1),
-            __timeout_cfg(2000.0),
+            __timeout_cfg(2000),
             __telnet_info(),
         ],
     )
@@ -458,7 +458,7 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
     except ValueError:
         return SetupError(error_type=IntegrationSetupError.OTHER)
 
-    timeout = float(msg.input_values.get("timeout", 2000.0))
+    timeout = int(msg.input_values.get("timeout", 2000))
 
     # Telnet connection isn't required for connection check and retrieving model information
     connect_denonavr = ConnectDenonAVR(
@@ -541,7 +541,7 @@ async def _handle_device_reconfigure(
     _reconfigured_device.zone3 = msg.input_values.get("zone3") == "true"
     _reconfigured_device.use_telnet = connection_mode == "use_telnet"
     _reconfigured_device.volume_step = volume_step
-    _reconfigured_device.timeout = float(msg.input_values.get("timeout", 2000.0))
+    _reconfigured_device.timeout = int(msg.input_values.get("timeout", 2000))
 
     config.devices.update(_reconfigured_device)  # triggers receiver instance update
     await asyncio.sleep(1)
@@ -588,11 +588,11 @@ def __volume_cfg(step: float):
     }
 
 
-def __timeout_cfg(timeout: float):
+def __timeout_cfg(timeout: int):
     return {
         "id": "timeout",
         "label": _a("Connection and request timeout"),
         "field": {
-            "number": {"value": timeout, "min": 250.0, "max": 10_000.0, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
+            "number": {"value": timeout, "min": 250, "max": 10_000, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
         },
     }

--- a/intg-denonavr/setup_flow.py
+++ b/intg-denonavr/setup_flow.py
@@ -304,7 +304,7 @@ async def handle_configuration_mode(
             else:
                 connection_mode = "use_http"
             volume_step = selected_device.volume_step if selected_device.volume_step else 0.5
-            timeout = selected_device.timeout if selected_device.timeout else 2.0
+            timeout = selected_device.timeout if selected_device.timeout else 2000.0
 
             return RequestUserInput(
                 _a("Configure your AVR"),
@@ -427,7 +427,7 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
             # },
             __connection_mode_cfg("use_telnet"),
             __volume_cfg(1),
-            __timeout_cfg(2.0),
+            __timeout_cfg(2000.0),
             __telnet_info(),
         ],
     )
@@ -458,7 +458,7 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
     except ValueError:
         return SetupError(error_type=IntegrationSetupError.OTHER)
 
-    timeout = int(msg.input_values.get("timeout", 2.0))
+    timeout = float(msg.input_values.get("timeout", 2000.0))
 
     # Telnet connection isn't required for connection check and retrieving model information
     connect_denonavr = ConnectDenonAVR(
@@ -541,7 +541,7 @@ async def _handle_device_reconfigure(
     _reconfigured_device.zone3 = msg.input_values.get("zone3") == "true"
     _reconfigured_device.use_telnet = connection_mode == "use_telnet"
     _reconfigured_device.volume_step = volume_step
-    _reconfigured_device.timeout = float(msg.input_values.get("timeout", 2.0))
+    _reconfigured_device.timeout = float(msg.input_values.get("timeout", 2000.0))
 
     config.devices.update(_reconfigured_device)  # triggers receiver instance update
     await asyncio.sleep(1)
@@ -593,6 +593,6 @@ def __timeout_cfg(timeout: float):
         "id": "timeout",
         "label": _a("Connection and request timeout"),
         "field": {
-            "number": {"value": timeout, "min": 0.250, "max": 10.0, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
+            "number": {"value": timeout, "min": 250.0, "max": 10_000.0, "steps": 1, "decimals": 0, "unit": {"en": "ms"}}
         },
     }


### PR DESCRIPTION
Changes the timeout to use seconds and not milliseconds. Also adds a migration step to fix the unit for those who already upgraded to the faulty version.