### PR TITLE
Include Marantz in the driver name

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,4 +1,4 @@
-# Internationalization (i18n) for Denon AVR Integration
+# Internationalization (i18n) for Denon/Marantz AVR Integration
 
 This project uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html) module for internationalization.
 

--- a/driver.json
+++ b/driver.json
@@ -3,7 +3,7 @@
   "version": "0.8.4",
   "min_core_api": "0.20.0",
   "name": {
-    "en": "Denon AVR Network Receivers"
+    "en": "Denon and Marantz AVR Network Receivers"
   },
   "icon": "uc:tv-music",
   "description": {

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -1,5 +1,5 @@
 """
-This module implements the Denon AVR receiver communication of the Remote Two integration driver.
+This module implements the Denon/Marantz AVR receiver communication of the Remote Two/3 integration driver.
 
 :copyright: (c) 2023 by Unfolded Circle ApS.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -106,7 +106,7 @@ _P = ParamSpec("_P")
 def async_handle_denonlib_errors(
     func: Callable[Concatenate[_DenonDeviceT, _P], Awaitable[ucapi.StatusCodes | None]],
 ) -> Callable[Concatenate[_DenonDeviceT, _P], Coroutine[Any, Any, ucapi.StatusCodes | None]]:
-    """Log errors occurred when calling a Denon AVR receiver.
+    """Log errors occurred when calling a Denon/Marantz AVR receiver.
 
     Decorates methods of DenonDevice class.
 
@@ -127,7 +127,7 @@ def async_handle_denonlib_errors(
             result = ucapi.StatusCodes.SERVICE_UNAVAILABLE
             if self.available:
                 _LOG.warning(
-                    "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable. (%s%s)",
+                    "Timeout connecting to Denon/Marantz AVR receiver at host %s. Device is unavailable. (%s%s)",
                     self._receiver.host,
                     func.__name__,
                     args,
@@ -138,7 +138,7 @@ def async_handle_denonlib_errors(
             available = False
             if self.available:
                 _LOG.warning(
-                    "Network error connecting to Denon AVR receiver at host %s. Device is unavailable. (%s%s)",
+                    "Network error connecting to Denon/Marantz AVR receiver at host %s. Device is unavailable. (%s%s)",
                     self._receiver.host,
                     func.__name__,
                     args,
@@ -150,7 +150,7 @@ def async_handle_denonlib_errors(
             if self.available:
                 _LOG.warning(
                     (
-                        "Denon AVR receiver at host %s responded with HTTP 403 error. "
+                        "Denon/Marantz AVR receiver at host %s responded with HTTP 403 error. "
                         "Device is unavailable. Please consider power cycling your "
                         "receiver. (%s%s)"
                     ),
@@ -171,7 +171,7 @@ def async_handle_denonlib_errors(
         except DenonAvrError as err:
             available = False
             _LOG.exception(
-                "Error %s occurred in method %s%s for Denon AVR receiver",
+                "Error %s occurred in method %s%s for Denon/Marants AVR receiver",
                 err,
                 func.__name__,
                 args,
@@ -179,7 +179,7 @@ def async_handle_denonlib_errors(
         finally:
             if available and not self.available:
                 _LOG.info(
-                    "Denon AVR receiver at host %s is available again",
+                    "Denon/Marantz AVR receiver at host %s is available again",
                     self._receiver.host,
                 )
                 self.available = True
@@ -189,7 +189,7 @@ def async_handle_denonlib_errors(
 
 
 class DenonDevice:
-    """Representing a Denon AVR Device."""
+    """Representing a Denon/Marantz AVR Device."""
 
     def __init__(
         self,
@@ -233,7 +233,7 @@ class DenonDevice:
         self._volume_step = device.volume_step
         self._update_lock = Lock()
 
-        _LOG.debug("Denon AVR created: %s", device.address)
+        _LOG.debug("Denon/Marantz AVR created: %s", device.address)
 
     @property
     def active(self) -> bool:
@@ -432,7 +432,7 @@ class DenonDevice:
                 )
 
             _LOG.info(
-                "Denon AVR connected. Manufacturer=%s, Model=%s, Name=%s, Id=%s, State=%s",
+                "Denon/Marantz AVR connected. Manufacturer=%s, Model=%s, Name=%s, Id=%s, State=%s",
                 self.manufacturer,
                 self.model_name,
                 self.name,

--- a/intg-denonavr/config.py
+++ b/intg-denonavr/config.py
@@ -38,7 +38,7 @@ def avr_from_entity_id(entity_id: str) -> str | None:
 
 @dataclass
 class AvrDevice:
-    """Denon device configuration."""
+    """Denon/Marantz device configuration."""
 
     id: str
     name: str
@@ -64,7 +64,7 @@ class _EnhancedJSONEncoder(json.JSONEncoder):
 
 
 class Devices:
-    """Integration driver configuration class. Manages all configured Denon devices."""
+    """Integration driver configuration class. Manages all configured Denon/Marantz devices."""
 
     def __init__(self, data_path: str, add_handler, remove_handler):
         """
@@ -126,7 +126,7 @@ class Devices:
         return None
 
     def update(self, avr: AvrDevice) -> bool:
-        """Update a configured Denon device and persist configuration."""
+        """Update a configured Denon/Marantz device and persist configuration."""
         for item in self._config:
             if item.id == avr.id:
                 item.address = avr.address

--- a/intg-denonavr/discover.py
+++ b/intg-denonavr/discover.py
@@ -1,5 +1,5 @@
 """
-Denon AVR device discovery with SSDP.
+Denon/Marantz AVR device discovery with SSDP.
 
 :copyright: (c) 2023 by Unfolded Circle ApS.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -14,9 +14,9 @@ _LOG = logging.getLogger(__name__)
 
 async def denon_avrs() -> list[dict]:
     """
-    Discover Denon AVRs on the network with SSDP.
+    Discover Denon/Marantz AVRs on the network with SSDP.
 
-    Returns a list of dictionaries which includes all discovered Denon AVR
+    Returns a list of dictionaries which includes all discovered Denon/Marantz AVR
     devices with keys "host", "modelName", "friendlyName", "presentationURL".
     By default, SSDP broadcasts are sent once with a 2 seconds timeout.
 

--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This module implements a Remote Two integration driver for Denon AVR receivers.
+This module implements a Remote Two/3 integration driver for Denon/Marantz AVR receivers.
 
 :copyright: (c) 2023 by Unfolded Circle ApS.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -48,7 +48,7 @@ async def receiver_status_poller(interval: float = 10.0) -> None:
 
 @api.listens_to(ucapi.Events.CONNECT)
 async def on_r2_connect_cmd() -> None:
-    """Connect all configured receivers when the Remote Two sends the connect command."""
+    """Connect all configured receivers when the Remote Two/3 sends the connect command."""
     _LOG.debug("R2 connect command: connecting device(s)")
     await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
     for receiver in _configured_avrs.values():
@@ -58,7 +58,7 @@ async def on_r2_connect_cmd() -> None:
 
 @api.listens_to(ucapi.Events.DISCONNECT)
 async def on_r2_disconnect_cmd():
-    """Disconnect all configured receivers when the Remote Two sends the disconnect command."""
+    """Disconnect all configured receivers when the Remote Two/3 sends the disconnect command."""
     for receiver in _configured_avrs.values():
         # start background task
         _LOOP.create_task(receiver.disconnect())
@@ -67,9 +67,9 @@ async def on_r2_disconnect_cmd():
 @api.listens_to(ucapi.Events.ENTER_STANDBY)
 async def on_r2_enter_standby() -> None:
     """
-    Enter standby notification from Remote Two.
+    Enter standby notification from Remote Two/3.
 
-    Disconnect every Denon AVR instances.
+    Disconnect every Denon/Marantz AVR instances.
     """
     global _R2_IN_STANDBY
 
@@ -82,9 +82,9 @@ async def on_r2_enter_standby() -> None:
 @api.listens_to(ucapi.Events.EXIT_STANDBY)
 async def on_r2_exit_standby() -> None:
     """
-    Exit standby notification from Remote Two.
+    Exit standby notification from Remote Two/3.
 
-    Connect all Denon AVR instances.
+    Connect all Denon/Marantz AVR instances.
     """
     global _R2_IN_STANDBY
 
@@ -340,7 +340,7 @@ async def _async_remove(receiver: avr.DenonDevice) -> None:
 
 
 async def main():
-    """Start the Remote Two integration driver."""
+    """Start the Remote Two/3 integration driver."""
     logging.basicConfig()  # when running on the device: timestamps are added by the journal
     # logging.basicConfig(
     #     format="%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",

--- a/intg-denonavr/i18n.py
+++ b/intg-denonavr/i18n.py
@@ -1,5 +1,5 @@
 """
-Internationalization support for the Denon AVR integration.
+Internationalization support for the Denon/Marantz AVR integration.
 
 This module provides functions for translating strings in the integration.
 It uses gettext for internationalization and proper pluralization support.

--- a/intg-denonavr/locales/README.md
+++ b/intg-denonavr/locales/README.md
@@ -1,4 +1,4 @@
-# Internationalization (i18n) for Denon AVR Integration
+# Internationalization (i18n) for Denon/Marantz AVR Integration
 
 This directory contains translation files for the Denon AVR integration. The integration uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html)
 module for internationalization.

--- a/intg-denonavr/locales/en_US/LC_MESSAGES/intg-denonavr.po
+++ b/intg-denonavr/locales/en_US/LC_MESSAGES/intg-denonavr.po
@@ -91,12 +91,12 @@ msgid "Configure your AVR"
 msgstr "Configure your AVR"
 
 #: ../setup_flow.py:401
-msgid "Please choose your Denon AVR"
-msgstr "Please choose your Denon AVR"
+msgid "Please choose your Denon or Marantz AVR"
+msgstr "Please choose your Denon or Marantz AVR"
 
 #: ../setup_flow.py:406
-msgid "Choose your Denon AVR"
-msgstr "Choose your Denon AVR"
+msgid "Choose your Denon or Marantz AVR"
+msgstr "Choose your Denon or Marantz AVR"
 
 #: ../setup_flow.py:556
 msgid "Show all sources"

--- a/intg-denonavr/media_player.py
+++ b/intg-denonavr/media_player.py
@@ -40,7 +40,7 @@ MEDIA_PLAYER_STATE_MAPPING = {
 
 
 class DenonMediaPlayer(MediaPlayer):
-    """Representation of a Denon Media Player entity."""
+    """Representation of a Denon/Marantz Media Player entity."""
 
     def __init__(self, device: AvrDevice, receiver: avr.DenonDevice):
         """Initialize the class."""
@@ -240,7 +240,7 @@ def state_from_avr(avr_state: avr.States) -> States:
     """
     Convert AVR state to UC API media-player state.
 
-    :param avr_state: Denon AVR state
+    :param avr_state: Denon/Marantz AVR state
     :return: UC API media_player state
     """
     if avr_state in MEDIA_PLAYER_STATE_MAPPING:

--- a/intg-denonavr/receiver.py
+++ b/intg-denonavr/receiver.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ConnectDenonAVR:
-    """Class to async connect to a DenonAVR receiver."""
+    """Class to async connect to a Denon/Marantz AVR receiver."""
 
     # pylint: disable=too-many-positional-arguments
     def __init__(
@@ -33,7 +33,7 @@ class ConnectDenonAVR:
         """
         Initialize the class.
 
-        :param host: IP address or hostname of the DenonAVR receiver.
+        :param host: IP address or hostname of the Denon/Marantz AVR receiver.
         :param timeout: connection timeout in milliseconds.
         :param show_all_inputs: show all inputs or only the enabled ones.
         :param zone2: enable zone 2 (not yet supported).
@@ -60,7 +60,7 @@ class ConnectDenonAVR:
         return self._receiver
 
     async def async_connect_receiver(self) -> bool:
-        """Connect to the DenonAVR receiver."""
+        """Connect to the Denon/Marantz AVR receiver."""
         await self.async_init_receiver_class()
         assert self._receiver
 

--- a/intg-denonavr/setup_flow.py
+++ b/intg-denonavr/setup_flow.py
@@ -1,5 +1,5 @@
 """
-Setup flow for Denon AVR integration.
+Setup flow for Denon/Marantz AVR integration.
 
 :copyright: (c) 2023 by Unfolded Circle ApS.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -156,7 +156,7 @@ async def handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Set
     """
     Start driver setup.
 
-    Initiated by Remote Two to set up the driver. The reconfigure flag determines the setup flow:
+    Initiated by Remote Two/3 to set up the driver. The reconfigure flag determines the setup flow:
 
     - Reconfigure is True: show the configured devices and ask user what action to perform (add, delete, reset).
     - Reconfigure is False: clear the existing configuration and show device discovery screen.
@@ -398,12 +398,12 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
 
     _setup_step = SetupSteps.DEVICE_CHOICE
     return RequestUserInput(
-        _a("Please choose your Denon AVR"),
+        _a("Please choose your Denon or Marantz AVR"),
         [
             {
                 "field": {"dropdown": {"value": dropdown_items[0]["id"], "items": dropdown_items}},
                 "id": "choice",
-                "label": _a("Choose your Denon AVR"),
+                "label": _a("Choose your Denon or Marantz AVR"),
             },
             __show_all_inputs_cfg(False),
             # TODO #21 support multiple zones
@@ -443,7 +443,7 @@ async def handle_device_choice(msg: UserDataResponse) -> SetupComplete | SetupEr
     :return: the setup action on how to continue: SetupComplete if a valid AVR device was chosen.
     """
     host = msg.input_values["choice"]
-    _LOG.debug("Chosen Denon AVR: %s. Trying to connect and retrieve device information...", host)
+    _LOG.debug("Chosen Denon/Marantz AVR: %s. Trying to connect and retrieve device information...", host)
 
     show_all_inputs = msg.input_values.get("show_all_inputs") == "true"
     update_audyssey = False  # not yet supported

--- a/intg-denonavr/simplecommand.py
+++ b/intg-denonavr/simplecommand.py
@@ -1,5 +1,5 @@
 """
-This module implements the Denon AVR receiver communication of the Remote Two integration driver.
+This module implements the Denon/Marantz AVR receiver communication of the Remote Two/3 integration driver.
 
 :copyright: (c) 2023 by Unfolded Circle ApS.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -332,7 +332,7 @@ class SimpleCommand:
         """
         Create a SimpleCommand instance.
 
-        :param receiver: Denon receiver instance
+        :param receiver: Denon/Marantz receiver instance
         :param send_command: Function to send a raw command to the receiver
         """
         self._receiver = receiver

--- a/tools/templates/licenses-header.md
+++ b/tools/templates/licenses-header.md
@@ -1,5 +1,5 @@
-# Denon integration for Remote Two
-The Unfolded Circle Denon integration for Remote Two is part of the firmware.
+# Denon/Marantz integration for Remote Two/3
+The Unfolded Circle Denon/Marantz integration for Remote Two/3 is part of the firmware.
 
 ## Licenses
 These are the licenses for the libraries we use in the shipped product as well as for development.


### PR DESCRIPTION
- Adjust strings to clarify that Marantz is supported as well.
- Make sure that we're consistent with the Remote Two/3 references.