### PR TITLE
Decrease the polling interval to keep state up to date

### DIFF
--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -526,11 +526,7 @@ class DenonDevice:
         if self._update_lock.locked() or not self._active or self._connecting:
             return
 
-        try:
-            await asyncio.wait_for(self._update_lock.acquire(), timeout=2.0)
-        except asyncio.TimeoutError:
-            _LOG.info("[%s] Update lock timeout, skipping update", self.id)
-            return
+        await self._update_lock.acquire()
 
         try:
             receiver = self._receiver

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -535,6 +535,7 @@ class DenonDevice:
             # the last update and is still healthy now to ensure that
             # we don't miss any state changes while telnet is down
             # or reconnecting.
+            # TODO: is this still needed?
             if (
                 telnet_is_healthy := receiver.telnet_connected and receiver.telnet_healthy
             ) and self._telnet_was_healthy:
@@ -678,6 +679,7 @@ class DenonDevice:
             volume_denon = float(18)
         await self._receiver.async_set_volume(volume_denon)
         self.events.emit(Events.UPDATE, self.id, {MediaAttr.VOLUME: volume})
+        # TODO: is this still needed?
         if self._use_telnet and not self._update_lock.locked():
             await self._event_loop.create_task(self.async_update_receiver_data())
         else:
@@ -731,7 +733,7 @@ class DenonDevice:
         await self._receiver.async_mute(muted)
         if not self._use_telnet:
             self.events.emit(Events.UPDATE, self.id, {MediaAttr.MUTED: muted})
-        else:
+        else:  # TODO: Is this still needed?
             await self.async_update_receiver_data()
         return ucapi.StatusCodes.OK
 

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -526,7 +526,11 @@ class DenonDevice:
         if self._update_lock.locked() or not self._active or self._connecting:
             return
 
-        await self._update_lock.acquire()
+        try:
+            await asyncio.wait_for(self._update_lock.acquire(), timeout=2.0)
+        except asyncio.TimeoutError:
+            _LOG.info("[%s] Update lock timeout, skipping update", self.id)
+            return
 
         try:
             receiver = self._receiver

--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -32,18 +32,21 @@ _R2_IN_STANDBY = False
 
 async def receiver_status_poller(interval: float = 10.0) -> None:
     """Receiver data poller."""
+    # TODO: is it important to delay the first call?
     while True:
-        await asyncio.sleep(interval)
-        if _R2_IN_STANDBY:
-            continue
-        try:
-            for receiver in _configured_avrs.values():
-                if not receiver.active:
-                    continue
-                # TODO #20  run in parallel, join, adjust interval duration based on execution time for next update
-                await receiver.async_update_receiver_data()
-        except (KeyError, ValueError):  # TODO check parallel access / modification while iterating a dict
-            pass
+        start_time = asyncio.get_event_loop().time()
+        if not _R2_IN_STANDBY:
+            try:
+                tasks = [
+                    receiver.async_update_receiver_data()
+                    for receiver in _configured_avrs.values()
+                    if receiver.active and not (receiver._use_telnet and receiver._telnet_was_healthy)
+                ]
+                await asyncio.gather(*tasks)
+            except (KeyError, ValueError):  # TODO check parallel access / modification while iterating a dict
+                pass
+        elapsed_time = asyncio.get_event_loop().time() - start_time
+        await asyncio.sleep(min(10.0, max(1.0, interval - elapsed_time)))
 
 
 @api.listens_to(ucapi.Events.CONNECT)
@@ -362,6 +365,7 @@ async def main():
     for device in config.devices.all():
         _configure_new_avr(device, connect=False)
 
+    # TODO: is this still needed for telnet?
     _LOOP.create_task(receiver_status_poller())
 
     await api.init("driver.json", setup_flow.driver_setup_handler)

--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -40,6 +40,7 @@ async def receiver_status_poller(interval: float = 10.0) -> None:
                 tasks = [
                     receiver.async_update_receiver_data()
                     for receiver in _configured_avrs.values()
+                    # pylint: disable=W0212
                     if receiver.active and not (receiver._use_telnet and receiver._telnet_was_healthy)
                 ]
                 await asyncio.gather(*tasks)


### PR DESCRIPTION
- Adjust the polling interval based on execution time.
- Only use polling for receivers using HTTP or when Telnet is unavailable
- Kick off update request when executing crucial commands to make sure that state is up to date