### PR TITLE
fix: telnet callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Telnet callbacks were no longer processed, stopping all dynamic state updates.
+
 ---
 
 ## v0.11.3 - 2025-11-25

--- a/intg-denonavr/avr.py
+++ b/intg-denonavr/avr.py
@@ -589,7 +589,7 @@ class DenonDevice:
         # None update object means data are up to date & client can fetch required data.
         self.events.emit(Events.UPDATE, self.id, None)
 
-    async def _telnet_callback(self, zone: str, event: str, parameter: str) -> None:
+    def _telnet_callback(self, zone: str, event: str, parameter: str) -> None:
         """Process a telnet command callback."""
         _LOG.debug("[%s] zone: %s, event: %s, parameter: %s", self.id, zone, event, parameter)
 


### PR DESCRIPTION
Dynamic state updates were no longer working, with one telnet related log message:
`RuntimeWarning: coroutine 'DenonDevice._telnet_callback' was never awaited`

The `_telnet_callback` method is defined as an asynchronous function, but the `denonavr` library calls it synchronously as a regular callback and does not `await` the returned coroutine.

However, the `_telnet_callback` method does not contain any `await` expressions, meaning it doesn't strictly require to be an `async` function. Easy fix!