### PR TITLE
Allow 4 repeats in remote entity again

### DIFF
--- a/intg-denonavr/denon_remote.py
+++ b/intg-denonavr/denon_remote.py
@@ -86,9 +86,8 @@ class DenonRemote(Remote):
 
         if params:
             repeat = self._get_int_param("repeat", params, 1)
-            # temporary hack for hold-down buttons sending a repeat count.
-            # This will be addressed with the upcoming press-and-hold feature.
-            if repeat < 1 or repeat == 4:
+            # Repeat must be between 1 and 20
+            if repeat < 1:
                 repeat = 1
             elif repeat > 20:
                 repeat = 20


### PR DESCRIPTION
Enable processing repeat 4 again since the issue with the timeout now should be fixed by not incorrectly sending `send_cmd` for each repeat.