### PR TITLE
fix: monitor output and audio delay sensors

### DIFF
--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -293,6 +293,7 @@ def _entities_from_avr(avr_id: str) -> list[str]:
             create_entity_id(avr_id, ucapi.EntityTypes.SENSOR, SensorType.SLEEP_TIMER.value),
             create_entity_id(avr_id, ucapi.EntityTypes.SENSOR, SensorType.AUDIO_DELAY.value),
             create_entity_id(avr_id, ucapi.EntityTypes.SENSOR, SensorType.MUTE.value),
+            create_entity_id(avr_id, ucapi.EntityTypes.SENSOR, SensorType.MONITOR_OUTPUT.value),
         ]
         MAPPED_AVR_ENTITIES[avr_id] = avr_entities
     return avr_entities


### PR DESCRIPTION
- monitor output sensor never showed the active output
- display value 0 numbers. Default audio delay 0 wasn't shown
- dynamically handle sleep unit: don't show `min` when off
- remove label names from values. A user can set a custom label