### PR TITLE
fix: avr_from_entity_id for sensor entity identifiers

### DIFF
--- a/intg-denonavr/config.py
+++ b/intg-denonavr/config.py
@@ -33,12 +33,19 @@ def avr_from_entity_id(entity_id: str) -> str | None:
 
     The prefix is the part before the first dot in the name and refers to the entity type (media-player or remote),
     the suffix is the AVR device identifier.
+    Sensor entity identifiers should be in the format ``sensor.<sensor_type>.<avr_id>``.
 
     :param entity_id: the entity identifier
     :return: the device suffix, or None if entity_id doesn't contain a dot
     """
     parts = entity_id.split(".", 1)
-    return parts[1] if len(parts) == 2 else None
+    avr_id = parts[1] if len(parts) == 2 else None
+    if avr_id is None:
+        return None
+    if parts[0] == "sensor":
+        parts = parts[1].split(".")
+        avr_id = parts[1] if len(parts) == 2 else parts[0]
+    return avr_id
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,20 @@ from ucapi import EntityTypes
 
 
 class TestConfig(unittest.TestCase):
-    def test_avr_from_entity_id_with_valid_entity(self):
+    def test_avr_from_entity_id_with_valid_media_player_entity(self):
         entity_id = "media_player.denon_avr_1"
         result = avr_from_entity_id(entity_id)
         self.assertEqual("denon_avr_1", result, "Expected AVR suffix from a valid entity ID")
+
+    def test_avr_from_entity_id_with_valid_sensor_entity(self):
+        entity_id = "sensor.volume_db.denon_avr_1"
+        result = avr_from_entity_id(entity_id)
+        self.assertEqual("denon_avr_1", result, "Expected AVR suffix from a valid entity ID")
+
+    def test_avr_from_entity_id_with_invalid_sensor_entity_missing_sensor_type(self):
+        entity_id = "sensor.denon_avr_1"
+        result = avr_from_entity_id(entity_id)
+        self.assertEqual("denon_avr_1", result, "Expected AVR suffix from an invalid sensor entity ID")
 
     def test_avr_from_entity_id_with_invalid_entity_missing_dot(self):
         entity_id = "media_player_denon_avr_1"


### PR DESCRIPTION
Sensor entity identifiers are defined as `sensor.<sensor_type>.<avr_id>`