### PR TITLE
build: update denonavrlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyee~=13.0.0
 ucapi==0.5.1
-denonavr@git+https://github.com/henrikwidlund/denonavr.git@8ccb43a439b62b4d383b01ee08259f6c160db9cc
+denonavr@git+https://github.com/henrikwidlund/denonavr.git@771889c5161cd215edfd7b5c7fb884bdc72c97a5


### PR DESCRIPTION
Prevent log flooding with stack traces if a background task throws an error because the Denon AVR connection fails.