### PR TITLE
fix: create a custom driver.json for the custom driver archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
               "cd /workspace && \
               PYTHON_VERSION=\$(python --version | cut -d' ' -f2 | cut -d. -f1,2) && \
               pip install --user -r requirements.txt && \
+              python intg-denonavr/custom_driver.py && \
               PYTHONPATH=~/.local/lib/python\${PYTHON_VERSION}/site-packages:\$PYTHONPATH pyinstaller --clean --onedir \
                 --name intg-denonavr --add-data intg-denonavr/locales:locales intg-denonavr/driver.py" -y
           echo "Clean up locales"
@@ -121,8 +122,8 @@ jobs:
           mv dist/intg-denonavr artifacts/
           mv artifacts/intg-denonavr artifacts/bin
           mv artifacts/bin/intg-denonavr artifacts/bin/driver
-          # patch metadata to not conflict with pre-installed driver
-          jq '.driver_id = "denonavr_custom" | .name.en = "Denon and Marantz AVR Network Receivers custom"' driver.json > artifacts/driver.json
+          # use patched driver.json from the intg-appletv/custom_driver.py script above to not conflict with pre-installed driver
+          mv driver_custom.json artifacts/driver.json
           cp LICENSE artifacts/
           echo "ARTIFACT_NAME=uc-intg-${{ env.INTG_NAME }}-${{ env.VERSION }}-aarch64" >> $GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ ENV/
 
 .DS_Store
 config.json
+driver_custom.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Create a valid driver.json file in the custom driver archive with custom driver_id and name.
+
 ### Changed
 - Update ucapi to 0.6.0 
 

--- a/intg-denonavr/custom_driver.py
+++ b/intg-denonavr/custom_driver.py
@@ -1,0 +1,23 @@
+"""
+Helper script to create a custom driver.json configuration in the build process.
+
+:copyright: (c) 2026 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import json
+from pathlib import Path
+
+from i18n import _a
+from setup_flow import setup_data_schema
+
+with open(Path(__file__).parent / ".." / "driver.json", "r", encoding="utf-8") as file:
+    driver_info = json.load(file)
+
+    driver_info["driver_id"] = "denonavr_custom"
+    driver_info["name"]["en"] = "Denon and Marantz AVR Network Receivers custom"
+    driver_info["description"] = _a("Control your Denon or Marantz AVRs with Remote Two/3.")
+    driver_info["setup_data_schema"] = setup_data_schema()
+
+    with open(Path(__file__).parent / ".." / "driver_custom.json", "w", encoding="utf-8") as f:
+        json.dump(driver_info, f, ensure_ascii=False, indent=2)

--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -445,6 +445,7 @@ async def main():
     await api.init("driver.json", setup_flow.driver_setup_handler)
 
     # temporary hack to change driver.json language texts until supported by the wrapper lib # pylint: disable=W0212
+    # Attention: keep in sync with `custom_config.py`!
     api._driver_info["description"] = _a("Control your Denon or Marantz AVRs with Remote Two/3.")
     api._driver_info["setup_data_schema"] = setup_flow.setup_data_schema()  # pylint: disable=W0212
 


### PR DESCRIPTION
A custom integration driver archive requires a full driver.json file.

The locally installed driver and when running as an external integration driver used to create the driver information data dynamically.

For a custom integration driver this results in an empty main setup flow page, and a failed setup flow!