### PR TITLE
fix: prevent status poller task from dying on unexpected errors

### DIFF
--- a/intg-denonavr/driver.py
+++ b/intg-denonavr/driver.py
@@ -60,16 +60,17 @@ async def receiver_status_poller(interval: float = 10.0) -> None:
     """Receiver data poller."""
     # TODO: is it important to delay the first call?
     while True:
-        start_time = asyncio.get_event_loop().time()
+        start_time = _LOOP.time()
         if not _REMOTE_IN_STANDBY:
-            try:
-                tasks = [
-                    receiver.async_update_receiver_data() for receiver in _configured_avrs.values() if receiver.active
-                ]
-                await asyncio.gather(*tasks)
-            except (KeyError, ValueError):  # TODO check parallel access / modification while iterating a dict
-                pass
-        elapsed_time = asyncio.get_event_loop().time() - start_time
+            # snapshot the configured receivers: the dict may be modified while updates are running
+            receivers = [receiver for receiver in list(_configured_avrs.values()) if receiver.active]
+            results = await asyncio.gather(
+                *(receiver.async_update_receiver_data() for receiver in receivers), return_exceptions=True
+            )
+            for receiver, result in zip(receivers, results, strict=True):
+                if isinstance(result, BaseException):
+                    _LOG.error("[%s] Receiver update failed", receiver.id, exc_info=result)
+        elapsed_time = _LOOP.time() - start_time
         await asyncio.sleep(min(10.0, max(1.0, interval - elapsed_time)))
 
 


### PR DESCRIPTION
## Problem

`receiver_status_poller` in `intg-denonavr/driver.py` is the only source of periodic entity updates (essential in HTTP mode, and the safety net when the telnet connection is unhealthy). It only caught `KeyError` and `ValueError`; `asyncio.gather()` without `return_exceptions=True` propagates the first exception of any other type (e.g. `AttributeError`, `RuntimeError`, or anything escaping the denonavr error handling) out of the `while True` loop, killing the background task **permanently**.

Symptom: after one malformed AVR response or unexpected library error, all entity states (volume, source, power) freeze until the driver is restarted, while commands still work.

## Fix

- Gather the per-receiver update coroutines with `return_exceptions=True` and log failures per receiver instead of letting them terminate the polling loop.
- Snapshot the configured receivers list before gathering, so concurrent configuration changes (device added/removed during setup) cannot affect the iteration. This also resolves the old `TODO check parallel access / modification while iterating a dict`.

## Verification

- `PYTHONPATH=intg-denonavr python -m unittest discover tests` — 38 tests OK
- `ruff check`, `ruff format --check`, `pyright` (strict) — clean

---

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>