### PR TITLE
feat: Only persist git token when needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           # History of 200 should be more than enough to calculate commit count since last release tag.
           fetch-depth: 200
-          persist-credentials: true # Needed by git operations in "Fetch all tags to determine version"
+          persist-credentials: false
 
       - name: Fetch all tags to determine version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           # History of 200 should be more than enough to calculate commit count since last release tag.
           fetch-depth: 200
-          submodules: recursive
+          persist-credentials: true # Needed by git operations in "Fetch all tags to determine version"
 
       - name: Fetch all tags to determine version
         run: |
@@ -191,6 +191,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: main
+          persist-credentials: false
 
       # We have to delete the "latest" release, otherwise `softprops/action-gh-release` will only append the new artifact.
       # This simulates the old marvinpinto/action-automatic-releases action.

--- a/.github/workflows/python-code-format.yml
+++ b/.github/workflows/python-code-format.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          submodules: recursive
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
# Description

Improve pipeline security by not persisting the git token unless it's needed in other steps.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Can't be tested / covered by GHA runs

# Checklist:

- [x] My code follows the [code guidelines](https://github.com/unfoldedcircle/integration-denonavr/blob/main/docs/code_guidelines.md) of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks (see [code guidelines](https://github.com/unfoldedcircle/integration-denonavr/blob/main/docs/code_guidelines.md)) and unit tests `python -m unittest discover tests`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code
